### PR TITLE
Add GitHub Actions CI for tests and wasm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel in-flight runs for the same branch/PR when new commits land.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # `[profile.test] opt-level = 3` makes a cold build slow because
+      # `Scores::new()` is exercised in tests; the cache makes warm runs fast.
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo build (tests)
+        run: cargo build --workspace --tests
+
+      - name: cargo test
+        run: cargo test --workspace
+
+  wasm:
+    name: wasm-pack build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/wasm
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: wasm-pack build
+        working-directory: crates/wasm
+        run: wasm-pack build --target web --out-dir pkg


### PR DESCRIPTION
Runs `cargo test --workspace` and `wasm-pack build` for `crates/wasm` on every push to master and every pull request. Builds are cached with Swatinem/rust-cache so repeat runs avoid recompiling the slow `opt-level = 3` test profile from scratch.

Lint jobs (rustfmt, clippy) are intentionally omitted for now: the existing tree has rustfmt diffs and clippy warnings that would need a one-time cleanup before they can be enforced.