### PR TITLE
Web: lift joker-rule helper, harden entryScore, name lower-row indices

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import init, { Solver, achievableScores, entryScore } from 'yahtzee-wasm';
-  import { ENTRY_LABELS, PIP_POS, YAHTZEE_IDX } from './constants';
+  import { ENTRY_LABELS, JOKER_LOWER_IDXS, PIP_POS, YAHTZEE_IDX } from './constants';
   import {
     cycleFace,
     formatAllowed,
+    isJokerActive,
     isYahtzee,
     keepMaskFor,
     maxYahtzeeBonuses as maxYahtzeeBonusesFor,
@@ -136,6 +137,10 @@
 
   $effect(() => {
     if (!solver) return;
+    // No recommendations to compute once every entry is filled — the wasm's
+    // notion of a recommendation only makes sense at non-terminal states, and
+    // the UI hides this panel behind the game-over screen anyway.
+    if (gameOver) return;
     try {
       rec = solver.recommend(stateInput, new Uint8Array(dice), roll) as Recommendation;
       recError = null;
@@ -154,19 +159,13 @@
   // already filled (any value), AND the matching upper box is already filled.
   // Lower-row categories then accept fixed joker scores (full house = 25,
   // small straight = 30, large straight = 40).
-  const jokerActive = $derived.by(() => {
-    const c = [0, 0, 0, 0, 0, 0];
-    for (const v of dice) c[v - 1]++;
-    const face = c.findIndex(x => x === 5) + 1;
-    if (face === 0) return false;
-    return scores[YAHTZEE_IDX] !== null && scores[face - 1] !== null;
-  });
+  const jokerActive = $derived(isJokerActive(dice, scores));
 
   // Highlight the joker-rule indicator only on lower-row "shaped" categories
   // (full house, small straight, large straight) — those are the ones that
   // accept the special joker score.
   function isJokerEnabled(i: number): boolean {
-    return jokerActive && (i === 8 || i === 9 || i === 10);
+    return jokerActive && (JOKER_LOWER_IDXS as readonly number[]).includes(i);
   }
 
   const choices = $derived(buildChoices(rec));
@@ -255,8 +254,19 @@
   function applyScore(idx: number) {
     if (gameOver) return;
     if (idx < 0 || idx >= 13) return;
+    let val: number;
+    try {
+      val = entryScore(stateInput, new Uint8Array(dice), idx);
+    } catch (e) {
+      // The free `entryScore` wasm function can in principle reject inputs
+      // (out-of-range entry index, malformed state). The UI only ever calls
+      // it with values it just received from `recommend`, so this should be
+      // unreachable — but surface the error rather than silently no-op'ing,
+      // and don't dirty the undo history with a half-applied turn.
+      recError = String(e);
+      return;
+    }
     pushHistory();
-    const val = entryScore(stateInput, new Uint8Array(dice), idx);
     rawInputs[idx] = String(val);
     // Auto-track Yahtzee bonuses: a fresh Yahtzee scored anywhere except the
     // Yahtzee box itself, while already eligible (= Yahtzee box holds 50),

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -6,8 +6,19 @@ export const ENTRY_LABELS = [
   'Small straight', 'Large straight', 'Yahtzee', 'Chance',
 ] as const;
 
-export const YAHTZEE_IDX = 11;
+export const FULL_HOUSE_IDX = 8;
 export const SMALL_STRAIGHT_IDX = 9;
+export const LARGE_STRAIGHT_IDX = 10;
+export const YAHTZEE_IDX = 11;
+
+/// Lower-row entries that accept the Joker rule's fixed scores (25 / 30 / 40)
+/// when a Yahtzee is rolled and the matching upper box + Yahtzee box are both
+/// already filled. Order matches scorecard order.
+export const JOKER_LOWER_IDXS = [
+  FULL_HOUSE_IDX,
+  SMALL_STRAIGHT_IDX,
+  LARGE_STRAIGHT_IDX,
+] as const;
 
 export const HOW_TO_SCORE = [
   'count 1s', 'count 2s', 'count 3s', 'count 4s', 'count 5s', 'count 6s',

--- a/web/src/scoring.test.ts
+++ b/web/src/scoring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   cycleFace,
   formatAllowed,
+  isJokerActive,
   isYahtzee,
   keepMaskFor,
   maxYahtzeeBonuses,
@@ -11,6 +12,60 @@ import {
   type AllowedScores,
 } from './scoring';
 import { SMALL_STRAIGHT_IDX, YAHTZEE_IDX } from './constants';
+
+describe('isJokerActive', () => {
+  // Build a 13-slot scorecard with given fills. `fills` maps idx → value
+  // (use 0 for "filled with forfeit", 50 for "scored Yahtzee", etc.).
+  function scorecard(fills: Record<number, number>): (number | null)[] {
+    const s: (number | null)[] = new Array(13).fill(null);
+    for (const [k, v] of Object.entries(fills)) s[Number(k)] = v;
+    return s;
+  }
+
+  test('non-Yahtzee dice → false regardless of scorecard', () => {
+    expect(isJokerActive([1, 2, 3, 4, 5], scorecard({}))).toBe(false);
+    // Even with everything filled, dice aren't a Yahtzee.
+    expect(isJokerActive([1, 1, 1, 1, 2], scorecard({
+      0: 5, [YAHTZEE_IDX]: 50,
+    }))).toBe(false);
+  });
+
+  test('Yahtzee dice but Yahtzee box unfilled → false', () => {
+    // Rolled Yahtzee of 3s, but Yahtzee box still empty: not yet a joker
+    // (you'd score this *as* a Yahtzee for 50).
+    expect(isJokerActive([3, 3, 3, 3, 3], scorecard({ 2: 9 }))).toBe(false);
+  });
+
+  test('Yahtzee dice + Yahtzee box filled but matching upper unfilled → false', () => {
+    // Rolled Yahtzee of 4s, Yahtzee box scored, but Fours row still empty:
+    // the right move is to score this as Fours (= 20), not joker.
+    expect(isJokerActive([4, 4, 4, 4, 4], scorecard({
+      [YAHTZEE_IDX]: 50,
+    }))).toBe(false);
+  });
+
+  test('Yahtzee dice + both Yahtzee box and matching upper filled → true', () => {
+    // Rolled Yahtzee of 6s; Sixes already scored 24, Yahtzee already 50.
+    expect(isJokerActive([6, 6, 6, 6, 6], scorecard({
+      5: 24, [YAHTZEE_IDX]: 50,
+    }))).toBe(true);
+  });
+
+  test('Yahtzee box scored as 0 (forfeit) still counts as filled', () => {
+    // Forfeit Yahtzee: the rule still enables joker on subsequent Yahtzees.
+    expect(isJokerActive([2, 2, 2, 2, 2], scorecard({
+      1: 8, [YAHTZEE_IDX]: 0,
+    }))).toBe(true);
+  });
+
+  test('upper box scored as 0 still counts as filled', () => {
+    // Imagine the player crossed off the Ones row earlier. Now they roll a
+    // Yahtzee of 1s with Yahtzee already scored — joker fires.
+    expect(isJokerActive([1, 1, 1, 1, 1], scorecard({
+      0: 0, [YAHTZEE_IDX]: 50,
+    }))).toBe(true);
+  });
+});
 
 describe('isYahtzee', () => {
   test('all-same returns true', () => {

--- a/web/src/scoring.ts
+++ b/web/src/scoring.ts
@@ -1,11 +1,36 @@
 // Pure dice/category helpers used by the UI. Nothing here touches Svelte
 // state or the wasm — they're plain functions you can unit-test in isolation.
 
-import { SMALL_STRAIGHT_IDX } from './constants';
+import { SMALL_STRAIGHT_IDX, YAHTZEE_IDX } from './constants';
 
 /** All 5 dice the same face. */
 export function isYahtzee(dice: number[]): boolean {
   return dice.every(v => v === dice[0]);
+}
+
+/**
+ * Does the Joker rule fire for the current dice + scorecard state?
+ *
+ * Conditions (per official Yahtzee rules):
+ *   1. The dice are a Yahtzee (all 5 the same face).
+ *   2. The Yahtzee box is already filled (any value — including 0, the
+ *      forfeit case — counts).
+ *   3. The matching upper box (Ones for a Yahtzee of 1s, etc.) is already
+ *      filled.
+ *
+ * When active, the lower-row "shaped" categories (Full House / Small
+ * Straight / Large Straight) accept fixed joker scores (25 / 30 / 40).
+ *
+ * `scores` is indexed by canonical entry index (`scores[YAHTZEE_IDX]`,
+ * `scores[face - 1]` for upper rows); `null` means "not yet filled".
+ */
+export function isJokerActive(
+  dice: number[],
+  scores: readonly (number | null)[],
+): boolean {
+  if (!isYahtzee(dice)) return false;
+  const face = dice[0]; // 1..6 by construction
+  return scores[YAHTZEE_IDX] !== null && scores[face - 1] !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Frontend review pass on `web/`. Three small wins, all surgical:

- **Lift `jokerActive` to a pure `isJokerActive(dice, scores)` in `scoring.ts`.** Was inline `$derived.by` in `App.svelte` doing its own Yahtzee detection; now reuses `isYahtzee` and is unit-testable. Adds 6 tests covering non-Yahtzee dice, Yahtzee + Yahtzee box unfilled, Yahtzee + box filled but matching upper unfilled, both filled, and the 0-as-forfeit cases for Yahtzee box and upper box.
- **Name the lower-row joker indices.** New `FULL_HOUSE_IDX`, `LARGE_STRAIGHT_IDX`, `JOKER_LOWER_IDXS` in `constants.ts` replace bare `i === 8 || i === 9 || i === 10` in `isJokerEnabled`.
- **Harden the wasm boundary in `applyScore`.** The `entryScore` call was the only unguarded wasm boundary in the UI; now wrapped in try/catch with `pushHistory()` moved below it, so a wasm throw can't dirty the undo stack.
- **Skip the `recommend` `$effect` on gameOver.** Wasted work + a possible terminal-state error path on the wasm side; the panel is hidden behind the game-over screen anyway.

## Test plan

- [x] `pnpm test` — 49/49 pass (was 43/43; +6 `isJokerActive` cases)
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm build` — clean
- [ ] `pnpm e2e` — not run; changes are surgical (no behavior shifts to dice/keep/roll/scorecard flow), but worth a smoke check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)