### PR TITLE
Add time_build example for ad-hoc rayon scaling measurements

### DIFF
--- a/crates/core/examples/time_build.rs
+++ b/crates/core/examples/time_build.rs
@@ -1,0 +1,26 @@
+//! Times `Scores::new()` (the rayon-parallelized DP table build) and prints
+//! the wall time and the EV of the default state. Used for ad-hoc rayon
+//! scaling measurements; not part of the normal test/bench suite.
+//!
+//! Run with e.g.
+//!
+//!     RAYON_NUM_THREADS=1  cargo run -p yahtzee-core --release --example time_build
+//!     RAYON_NUM_THREADS=8  cargo run -p yahtzee-core --release --example time_build
+//!
+//! Output is one line: `threads=<n> elapsed_ms=<ms> default_ev=<ev>`.
+
+use std::time::Instant;
+
+use yahtzee_core::{Scores, State};
+
+fn main() {
+    let threads = std::env::var("RAYON_NUM_THREADS").unwrap_or_else(|_| "default".to_string());
+    let t0 = Instant::now();
+    let scores = Scores::new();
+    let elapsed = t0.elapsed();
+    let ev = scores.state_value(State::default());
+    println!(
+        "threads={threads} elapsed_ms={:.1} default_ev={ev:.4}",
+        elapsed.as_secs_f64() * 1000.0
+    );
+}


### PR DESCRIPTION
## Summary
  - Adds `crates/core/examples/time_build.rs` — a tiny standalone binary that times `Scores::new()` with `Instant` and prints threads / elapsed / EV.                                                                               
  - Used to confirm rayon scales near-linearly to the 8 physical cores on a 9800X3D (1.0× → 7.5× at 8T, 10.2× at 16T) and to verify EV stays at 254.5897 across thread counts.                                                    
  - Not part of the test/bench suite; run on demand.