### PR TITLE
Backend abstraction: swap-in linalg / build backends (ndarray, faer, simd, cuda, naive).

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ Cargo workspace (`Cargo.toml` lists members; the root is not a crate):
 - CLI: `cargo run -p yahtzee-cli --release -- --help`. Subcommands are `solve`, `value`, `play`, and `build`. The CLI binary embeds a brotli-compressed score table at compile time (canonical artifact: `crates/cli/data/scores.bin.br`, ~1 MiB, tracked in git), so `solve` / `value` / `play` work out of the box with no `--scores` flag. `--scores PATH` overrides the embed with a raw bincode file from disk — useful when iterating on `crates/core` without rebuilding the CLI. `play` is an interactive game loop; pass `--auto --seed N` for a deterministic solver-vs-itself game (used by `tests/play_auto.rs`), `--manual-dice` for a real-game coach. `build` regenerates the table; the web bundle uses `build --output crates/cli/data/scores.bin --brotli`, which also writes the `.br` and a `MANIFEST` and updates the embed source for the next CLI rebuild.
 - Rebuild wasm after touching `crates/core` or `crates/wasm`: `cd crates/wasm && wasm-pack build --target web --out-dir pkg`. The Svelte dev server picks up the new `pkg/` automatically.
 - Web dev: `cd web && npx vite` (or `pnpm run dev` if pnpm is available). Type check: `npx svelte-check --tsconfig ./tsconfig.json`. Production build: `npx vite build`.
+- Time `Scores::new()` ad-hoc (rayon scaling, perf experiments): `RAYON_NUM_THREADS=N cargo run -p yahtzee-core --release --example time_build` (default ndarray backend), or `... --example time_build_naive` (naive scalar backend), or `... --example cuda_smoke --features cuda` (GPU). All print one-line timings; `cuda_smoke` also asserts the default-state EV.
+- Per-level DP-build trace: set `YAHTZEE_TRACE_LEVELS=1` on any of the above to print `level=N batch=B collect=…ms compute=…ms write=…ms` for each of the 13 DP levels. Useful when comparing backends at finer-than-total-wall-time granularity.
+- Criterion benches: `cargo bench -p yahtzee-core --bench recommend [--features cuda,faer,simd] -- "Scores::new_with|state_value/backends"` runs the head-to-head across naive / ndarray / faer / simd / cuda. The full-build group has `sample_size=10` and `measurement_time=60s`, so it can run for ~5 min with all features enabled — that's expected. Other bench groups (`Scores::values`, `recommend(default,[1..5])`, `*_with_turn_ev`) are quick.
 
 The web app expects `scores.bin.br` (brotli-compressed `Scores`) at `crates/cli/data/scores.bin.br` — the same file the CLI embeds. The dev-server middleware in `web/vite.config.ts` reads from there and streams it at `/scores.bin` with `Content-Encoding: br`. There is no longer a separate `web/static/scores.bin.br`.
 
@@ -41,9 +44,11 @@ A `State` is `(entries: EntryAction bitflags, yahtzee_bonus_eligible: bool, uppe
 
 ### Solver (`Scores`)
 
-`Scores::new()` allocates `state_scores: Array1<f32>` of length `NUM_STATES` and fills it level-by-level from 13 filled entries down to 0 (`set_scores`). Each level is parallelized with `rayon` (`par_iter_mut`); correctness of the parallelism depends on processing strictly higher levels first, since a state only depends on states with more entries filled.
+`Scores::new()` allocates `state_scores: Array1<f32>` of length `NUM_STATES` and fills it level-by-level from 13 filled entries down to 0 (`set_scores`). Within a level all states are independent (a state only reads entries of `state_scores` at strictly higher levels), and that's the parallelism dispatched through the [`BuildBackend`](#linalg-and-build-backends) trait — by default `CpuBuildBackend` does it as a rayon `par_iter` over the per-state walk; the GPU backend does the whole batch in one custom-kernel + cuBLAS pipeline per level.
 
-`Scores::values(state)` returns an `ExpectedValues` by walking the three-roll decision tree in reverse:
+`Scores::new_with<B: BuildBackend>(backend: &B) -> Result<Self, B::Error>` is the generic constructor; `Scores::new()` calls it with `&CpuBuildBackend` and unwraps the `Infallible` result. Use `new_with` directly to opt into a non-default backend (e.g. `&CudaBuildBackend::new()?` under the `cuda` feature).
+
+`Scores::values(state)` returns an `ExpectedValues` by walking the three-roll decision tree in reverse, dispatching the linalg ops through a [`LinalgBackend`](#linalg-and-build-backends):
 
 1. `entry_actions[action, dice]` = immediate score of taking `action` on `dice` + stored EV of the resulting child state (via `State::score_and_child`, which handles upper bonus, Yahtzee bonus, and the joker rule).
 2. `third_dice[dice] = max_action entry_actions[action, dice]` (best entry to pick on the final roll).
@@ -51,6 +56,48 @@ A `State` is `(entries: EntryAction bitflags, yahtzee_bonus_eligible: bool, uppe
 4. Overall EV = initial-roll distribution (row 0 of `KEEPERS_TO_DICE_PROBABILITIES`) · `first_dice`.
 
 The expected value from the default state is ~254.5896 (asserted in `test_expected_value`).
+
+Both per-state primitives also exist as **free functions** in the crate root: `pub fn state_value_with(state, state_scores: &[f32], &impl LinalgBackend) -> f32` and `pub fn values_with(...)`. The `Scores::*_with` methods are 1-line wrappers; the free-function form is what `BuildBackend` impls call so they don't need a `Scores` value.
+
+### Linalg and build backends
+
+There are **two** swappable abstractions, at different granularities:
+
+`LinalgBackend` — *per-state* primitives. Three ops: `keepers_from_dice` (252→462 GEMV), `dice_from_keepers` (462→252 masked-max reduction), `initial_roll_ev` (252-dim dot). Implementations live in `crates/core/src/linalg.rs`:
+
+| Backend | Cargo feature | What it does |
+|---|---|---|
+| `NaiveBackend` | (always-on, no deps) | Reference impl: nested scalar `for` loops over `&[f32]`. No ndarray ops. Independent of the others' code paths, so it doubles as the cross-check oracle (`test_naive_backend_matches`). |
+| `NdarrayBackend` | (default) | GEMV via `ndarray::Array2::dot` (which is `matrixmultiply` by default; `cblas_sgemv` under `--features blas`). Masked-max via a hand-rolled `Zip`. **What `Scores::new()` and `Scores::values()` use by default.** |
+| `FaerBackend` | `--features faer` | GEMV via faer's `Mat * Col`. Holds a preprocessed `faer::Mat` of `KEEPERS_TO_DICE_PROBABILITIES`. Reuses ndarray's masked-max (faer can't help with that). |
+| `SimdBackend` | `--features simd` | Hand-vectorized masked-max via `wide::f32x8`. GEMV stays on ndarray's `.dot()`. The masked-max acceleration is the single biggest CPU win — see perf table below. |
+
+`BuildBackend` — *per-level* batched. One method, `compute_level(states: &[State], state_scores: &[f32]) -> Result<Vec<f32>, Self::Error>`, with associated error type. CPU impls just dispatch the per-state walk in a rayon `par_iter`; the GPU impl owns the whole batched pipeline (uploads, NVRTC kernels, cuBLAS gemms, scatter back to device-resident state_scores).
+
+| Backend | Cargo feature | What it does |
+|---|---|---|
+| `CpuBuildBackend` | (always-on) | Convenience unit-struct: rayon `par_iter` over the per-state walk using `NdarrayBackend`. What `Scores::new()` uses. `Error = Infallible`. |
+| `CpuBuildBackendWith<L: LinalgBackend>(pub L)` | (always-on) | Generic over the per-state linalg, so benches and external callers can drive a full table build through any `LinalgBackend` (e.g. `CpuBuildBackendWith(NaiveBackend)`, `CpuBuildBackendWith(SimdBackend)`). `Error = Infallible`. |
+| `CudaBuildBackend` | `--features cuda` | Full GPU pipeline. Lives in `crates/core/src/linalg/cuda.rs`. Uses `cudarc` (driver API + cuBLAS + NVRTC), dynamic-loaded — no `nvcc` or CUDA headers needed at build time, only `libcuda` / `libcublas` / `libnvrtc` `.so`s on the runtime host. Three custom NVRTC kernels (`build_third_dice`, `masked_max`, `initial_roll_ev`) plus two cuBLAS sgemm calls per level for the two `keepers_from_dice` GEMVs. State_scores is allocated **once** on device and updated in place via a `scatter_results` kernel — no per-level H→D upload of the host buffer. Per-level intermediates are persistent and lazily grown to the largest batch seen. `Error = CudaError`. |
+
+Performance picture (Ryzen 9 9800X3D + RTX 5070 Ti, criterion `Scores::new_with`, 16 threads):
+
+| Backend | Build time | vs naive | Notes |
+|---|---|---|---|
+| `naive` | 8.69 s | 1.00× | The honest baseline. |
+| `ndarray` | 5.73 s | 1.52× | Default. matrixmultiply earns ~1.5× at our problem size. |
+| `faer` | 4.72 s | 1.84× | Quietly the best CPU GEMV at 252×462. |
+| `simd` | 3.11 s | 2.79× | Best CPU. Masked-max is the bottleneck SIMD attacks. |
+| `cuda` | 944 ms | 9.20× | Per-level batched on GPU; mostly architectural win, not "GPU linalg is 9× better." |
+
+Per-state (`state_value/backends`, default state, single thread): naive 162 µs → ndarray 116 µs → faer 99 µs → simd 53 µs. The CPU optimization machinery spans **2.79× over naive**; the GPU adds another 3.3× on top of that for ~9.2× end-to-end vs naive.
+
+For external comparison: the `timpalpant/yahtzee` Go reference takes ~45 s for the same table on the same hardware (16 threads). Our naive Rust is 5.2× faster than that, default Rust 7.9×, simd 14.6×, CUDA 48×. (Note: their start-state EV converges to 254.49, ours to 254.5896 — likely a small game-rule difference, possibly their `Max score is: 1500` cap on accumulated yahtzee bonuses; not investigated further.)
+
+Helpful entry points:
+- **Examples**: `crates/core/examples/time_build.rs` (default), `time_build_naive.rs`, `cuda_smoke.rs`.
+- **Benches**: `crates/core/benches/recommend.rs` — see the `bench_backends` (per-state) and `bench_build_backends` (full builds) groups.
+- **Cross-check test**: `test_naive_backend_matches` asserts naive and ndarray agree on default-state EV within 1e-3.
 
 ### Scoring helpers
 
@@ -71,12 +118,16 @@ Private helpers `turn_ev_by_roll3_dice()` and `turn_ev_by_roll2_dice(...)` build
 
 ## Serialization, CLI, wasm
 
-`Scores` derives `Serialize` / `Deserialize` and is persisted with `bincode`. The CLI (`crates/cli/src/main.rs`) either regenerates scores (`-o`) or loads them (`-i`), then for `--roll 1|2|3` prints ranked keepers / entries by EV. The `--entries` argument is a 13-character `0`/`1` string aligned with `ENTRY_ACTIONS` order.
+`Scores` derives `Serialize` / `Deserialize` and is persisted with `bincode`. The CLI (`crates/cli/src/main.rs`) is `clap`-subcommand-based — see the Commands section above for the four subcommands (`solve`, `value`, `play`, `build`) and how `--scores PATH` overrides the embedded score table. The `--entries` argument used by `solve` / `value` is a 13-character `0`/`1` string aligned with `ENTRY_ACTIONS` order.
+
+Both the CLI and wasm crates currently consume `yahtzee-core` with default features only (so the table-build path uses `CpuBuildBackend` → `NdarrayBackend`). The faster CPU backends (`simd`, `faer`) are gated behind features that neither downstream crate enables today; switching the CLI's `build` subcommand to use `simd` is a 1.84× wall-clock win with no API change. `cuda` is more situational (driver libs at runtime, NVIDIA-only) but plausible as an opt-in `cuda` feature on the CLI.
 
 `crates/wasm/src/lib.rs` exposes:
 
 - `class Solver` — `new(bytes)` deserializes a `scores.bin`. Methods: `recommend(state, dice, roll)` returns `{ value, keepers?, entries? }` where keeper/entry rows carry both `ev` (overall) and `turn_ev` (this turn), plus `best_entry` on keepers that have all 5 dice kept (= "stop rolling and score here"). `stateValue(state)` and `thisTurnEv(state, dice, roll)` are thin passthroughs.
 - Free functions `entryScore(state, dice, entry_idx) -> u8` and `achievableScores(entry_idx) -> Uint8Array` for UI scoring / validation without needing a `Solver` instance.
+
+Wasm doesn't *build* score tables at runtime (it deserializes the embedded brotli blob), so backend choice only affects the canonical `scores.bin.br` regeneration path that runs through the CLI's `build` subcommand. Whether to enable `simd` for wasm anyway (e.g. for any future runtime computation) is a separate question — `wide::f32x8` falls back to scalar on wasm targets without `wasm-simd128`, so it's safe to enable but a no-op without the wasm-simd128 target feature.
 
 ## Web app
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,12 +7,23 @@ edition = "2024"
 [lib]
 path = "src/lib.rs"
 
+[features]
+# Dispatch ndarray's `.dot()` on f32/f64 to a system BLAS (OpenBLAS via
+# pkg-config) instead of the default `matrixmultiply` backend. Currently
+# only affects the two `first_roll_probabilities().dot(&first_dice)` calls
+# in `Scores::values` / `Scores::state_value`; the keepers/dice transitions
+# are hand-rolled `Zip` loops and bypass ndarray's dot dispatch. Enable
+# with `cargo build -p yahtzee-core --features blas`.
+blas = ["ndarray/blas", "dep:blas-src", "dep:openblas-src"]
+
 [dependencies]
 bincode = { version = "2", features = ["serde"] }
 bitflags = { version = "2", features = ["serde"] }
 ndarray = { version = "0.16", features = ["serde", "rayon"] }
 rayon = "1"
 serde = { version = "1.0", features = ["derive"] }
+blas-src = { version = "0.10", features = ["openblas"], optional = true }
+openblas-src = { version = "0.10", features = ["system"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,11 @@ blas = ["ndarray/blas", "dep:blas-src", "dep:openblas-src"]
 # faer impl reuses the same Zip-based code as NdarrayBackend.)
 faer = ["dep:faer"]
 
+# Compile a `linalg::SimdBackend` that hand-vectorizes `dice_from_keepers`
+# (the masked max-reduction that BLAS/faer can't help with) using
+# `wide::f32x8`. Uses ndarray's `.dot()` for the GEMV. Off by default.
+simd = ["dep:wide", "dep:bytemuck"]
+
 [dependencies]
 bincode = { version = "2", features = ["serde"] }
 bitflags = { version = "2", features = ["serde"] }
@@ -29,6 +34,8 @@ serde = { version = "1.0", features = ["derive"] }
 blas-src = { version = "0.10", features = ["openblas"], optional = true }
 openblas-src = { version = "0.10", features = ["system"], optional = true }
 faer = { version = "0.24", default-features = false, features = ["std"], optional = true }
+wide = { version = "1.3", optional = true }
+bytemuck = { version = "1.25", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,12 +9,16 @@ path = "src/lib.rs"
 
 [features]
 # Dispatch ndarray's `.dot()` on f32/f64 to a system BLAS (OpenBLAS via
-# pkg-config) instead of the default `matrixmultiply` backend. Currently
-# only affects the two `first_roll_probabilities().dot(&first_dice)` calls
-# in `Scores::values` / `Scores::state_value`; the keepers/dice transitions
-# are hand-rolled `Zip` loops and bypass ndarray's dot dispatch. Enable
-# with `cargo build -p yahtzee-core --features blas`.
+# pkg-config) instead of the default `matrixmultiply` backend. Affects the
+# GEMV inside `NdarrayBackend::keepers_from_dice` and the scalar dot in
+# `NdarrayBackend::initial_roll_ev`. Enable with `--features blas`.
 blas = ["ndarray/blas", "dep:blas-src", "dep:openblas-src"]
+
+# Compile a `linalg::FaerBackend` impl of `LinalgBackend` that uses the
+# `faer` crate for the GEMV step. Off by default; opt-in for benchmarking.
+# (`dice_from_keepers` is a masked max-reduction and is unaffected -- the
+# faer impl reuses the same Zip-based code as NdarrayBackend.)
+faer = ["dep:faer"]
 
 [dependencies]
 bincode = { version = "2", features = ["serde"] }
@@ -24,6 +28,7 @@ rayon = "1"
 serde = { version = "1.0", features = ["derive"] }
 blas-src = { version = "0.10", features = ["openblas"], optional = true }
 openblas-src = { version = "0.10", features = ["system"], optional = true }
+faer = { version = "0.24", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,14 @@ faer = ["dep:faer"]
 # `wide::f32x8`. Uses ndarray's `.dot()` for the GEMV. Off by default.
 simd = ["dep:wide", "dep:bytemuck"]
 
+# Compile a `linalg::cuda::CudaBuildBackend` that runs the level-batched DP
+# fill on an NVIDIA GPU via cudarc (driver API + cuBLAS + NVRTC-compiled
+# custom kernels). This is a `BuildBackend` rather than a `LinalgBackend`:
+# the per-state `state_value*` paths stay on CPU, but `Scores::new_with`
+# dispatches each level's batch to the GPU. Off by default — opt in with
+# `--features cuda` and `Scores::new_with(&CudaBuildBackend::new()?)`.
+cuda = ["dep:cudarc"]
+
 [dependencies]
 bincode = { version = "2", features = ["serde"] }
 bitflags = { version = "2", features = ["serde"] }
@@ -36,6 +44,11 @@ openblas-src = { version = "0.10", features = ["system"], optional = true }
 faer = { version = "0.24", default-features = false, features = ["std"], optional = true }
 wide = { version = "1.3", optional = true }
 bytemuck = { version = "1.25", optional = true }
+# cudarc dynamic-loads libcuda / libcublas / libnvrtc at runtime via
+# `fallback-dynamic-loading`, so we don't need CUDA headers or `nvcc` at
+# build time — just the runtime `.so`s on `LD_LIBRARY_PATH` (or registered
+# with ldconfig). Driver API + cuBLAS + NVRTC are the bits we use.
+cudarc = { version = "0.19", default-features = false, features = ["cuda-12050", "driver", "cublas", "nvrtc", "std", "fallback-dynamic-loading"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/core/benches/recommend.rs
+++ b/crates/core/benches/recommend.rs
@@ -130,7 +130,8 @@ fn bench_build_backends(c: &mut Criterion) {
     let cpu = CpuBuildBackend;
     group.bench_function("cpu", |b| {
         b.iter(|| {
-            let s = Scores::new_with(black_box(&cpu));
+            // CpuBuildBackend's Error is Infallible; unwrap is statically safe.
+            let s = Scores::new_with(black_box(&cpu)).unwrap();
             black_box(s.state_value(State::default()))
         })
     });
@@ -148,7 +149,7 @@ fn bench_build_backends(c: &mut Criterion) {
         let cuda = &*CUDA_BACKEND;
         group.bench_function("cuda", |b| {
             b.iter(|| {
-                let s = Scores::new_with(black_box(cuda));
+                let s = Scores::new_with(black_box(cuda)).expect("CUDA build failed");
                 black_box(s.state_value(State::default()))
             })
         });

--- a/crates/core/benches/recommend.rs
+++ b/crates/core/benches/recommend.rs
@@ -15,10 +15,11 @@
 
 use std::hint::black_box;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use yahtzee_core::{
-    dice_to_counts, recommend, NdarrayBackend, Scores, State, StateInput,
+    dice_to_counts, recommend, CpuBuildBackend, NdarrayBackend, Scores, State, StateInput,
 };
 
 static SHARED_SCORES: LazyLock<Scores> = LazyLock::new(Scores::new);
@@ -115,11 +116,53 @@ fn bench_backends(c: &mut Criterion) {
     group.finish();
 }
 
+/// End-to-end `Scores::new_with(&backend)` head-to-head. Each iteration runs
+/// the full DP table build (set_valid_states + 13-level DP fill), so we
+/// override Criterion's defaults: sample_size = 10 (otherwise ~100 s per
+/// backend) and a generous measurement time. The CUDA backend is constructed
+/// once via `LazyLock` outside the timing loop — context init + NVRTC compile
+/// + static-table upload (~200 ms) is one-time setup, not per-build cost.
+fn bench_build_backends(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Scores::new_with");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    let cpu = CpuBuildBackend;
+    group.bench_function("cpu", |b| {
+        b.iter(|| {
+            let s = Scores::new_with(black_box(&cpu));
+            black_box(s.state_value(State::default()))
+        })
+    });
+
+    #[cfg(feature = "cuda")]
+    {
+        // One CUDA backend reused across all iterations so we time only the
+        // per-build work (kernel launches + per-level uploads), not context
+        // init + PTX compile.
+        static CUDA_BACKEND: LazyLock<yahtzee_core::linalg::cuda::CudaBuildBackend> =
+            LazyLock::new(|| {
+                yahtzee_core::linalg::cuda::CudaBuildBackend::new()
+                    .expect("CUDA backend init failed")
+            });
+        let cuda = &*CUDA_BACKEND;
+        group.bench_function("cuda", |b| {
+            b.iter(|| {
+                let s = Scores::new_with(black_box(cuda));
+                black_box(s.state_value(State::default()))
+            })
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_state_values,
     bench_recommend,
     bench_with_turn_ev,
     bench_backends,
+    bench_build_backends,
 );
 criterion_main!(benches);

--- a/crates/core/benches/recommend.rs
+++ b/crates/core/benches/recommend.rs
@@ -19,7 +19,8 @@ use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use yahtzee_core::{
-    dice_to_counts, recommend, CpuBuildBackend, NdarrayBackend, Scores, State, StateInput,
+    dice_to_counts, recommend, CpuBuildBackendWith, NaiveBackend, NdarrayBackend, Scores, State,
+    StateInput,
 };
 
 static SHARED_SCORES: LazyLock<Scores> = LazyLock::new(Scores::new);
@@ -82,15 +83,21 @@ fn bench_with_turn_ev(c: &mut Criterion) {
 }
 
 /// Side-by-side comparison of `LinalgBackend` impls on the same per-state
-/// EV path. NdarrayBackend is the default; whether it dispatches GEMV through
-/// `matrixmultiply` or OpenBLAS is a Cargo-feature decision (`--features blas`),
-/// so this group really compares "current ndarray build vs. faer". Run with
-/// `cargo bench -p yahtzee-core --features faer` to include FaerBackend.
+/// EV path. `naive` is the scalar-`for`-loop reference implementation;
+/// `ndarray` is the default (matrixmultiply, or OpenBLAS under
+/// `--features blas`); the others are opt-in feature gates. Run with
+/// `cargo bench -p yahtzee-core --features faer,simd` to include all CPU
+/// variants in one go.
 fn bench_backends(c: &mut Criterion) {
     let scores = &*SHARED_SCORES;
     let state = State::default();
 
     let mut group = c.benchmark_group("state_value/backends");
+
+    let nv = NaiveBackend;
+    group.bench_function("naive", |b| {
+        b.iter(|| black_box(scores.state_value_with(black_box(state), &nv)))
+    });
 
     let nd = NdarrayBackend;
     group.bench_function("ndarray", |b| {
@@ -116,31 +123,64 @@ fn bench_backends(c: &mut Criterion) {
     group.finish();
 }
 
-/// End-to-end `Scores::new_with(&backend)` head-to-head. Each iteration runs
-/// the full DP table build (set_valid_states + 13-level DP fill), so we
-/// override Criterion's defaults: sample_size = 10 (otherwise ~100 s per
-/// backend) and a generous measurement time. The CUDA backend is constructed
-/// once via `LazyLock` outside the timing loop — context init + NVRTC compile
-/// + static-table upload (~200 ms) is one-time setup, not per-build cost.
+/// End-to-end `Scores::new_with(&backend)` head-to-head. Each iteration
+/// runs the full DP table build (`set_valid_states` + 13-level DP fill),
+/// so we override Criterion's defaults: sample_size = 10 (otherwise ~100 s
+/// per backend) and a long measurement time. Naive can take ~14 s per
+/// iter, so the group can run for several minutes total — that's fine,
+/// criterion will exceed `measurement_time` to collect its 10 samples.
+///
+/// Each variant uses [`CpuBuildBackendWith`] so the comparison is a clean
+/// "same outer rayon scaffolding, swap only the per-state linalg." The
+/// CUDA arm is the exception: it's a different `BuildBackend` impl
+/// entirely (per-level GPU pipeline, not per-state CPU walk), reused
+/// across iterations via `LazyLock` so we time per-build work and not
+/// context init + NVRTC compile (~200 ms one-time).
 fn bench_build_backends(c: &mut Criterion) {
     let mut group = c.benchmark_group("Scores::new_with");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(60));
 
-    let cpu = CpuBuildBackend;
-    group.bench_function("cpu", |b| {
+    let naive = CpuBuildBackendWith(NaiveBackend);
+    group.bench_function("naive", |b| {
         b.iter(|| {
-            // CpuBuildBackend's Error is Infallible; unwrap is statically safe.
-            let s = Scores::new_with(black_box(&cpu)).unwrap();
+            let s = Scores::new_with(black_box(&naive)).unwrap();
             black_box(s.state_value(State::default()))
         })
     });
 
+    let ndarray = CpuBuildBackendWith(NdarrayBackend);
+    group.bench_function("ndarray", |b| {
+        b.iter(|| {
+            let s = Scores::new_with(black_box(&ndarray)).unwrap();
+            black_box(s.state_value(State::default()))
+        })
+    });
+
+    #[cfg(feature = "faer")]
+    {
+        let faer = CpuBuildBackendWith(yahtzee_core::linalg::FaerBackend::new());
+        group.bench_function("faer", |b| {
+            b.iter(|| {
+                let s = Scores::new_with(black_box(&faer)).unwrap();
+                black_box(s.state_value(State::default()))
+            })
+        });
+    }
+
+    #[cfg(feature = "simd")]
+    {
+        let simd = CpuBuildBackendWith(yahtzee_core::linalg::SimdBackend::new());
+        group.bench_function("simd", |b| {
+            b.iter(|| {
+                let s = Scores::new_with(black_box(&simd)).unwrap();
+                black_box(s.state_value(State::default()))
+            })
+        });
+    }
+
     #[cfg(feature = "cuda")]
     {
-        // One CUDA backend reused across all iterations so we time only the
-        // per-build work (kernel launches + per-level uploads), not context
-        // init + PTX compile.
         static CUDA_BACKEND: LazyLock<yahtzee_core::linalg::cuda::CudaBuildBackend> =
             LazyLock::new(|| {
                 yahtzee_core::linalg::cuda::CudaBuildBackend::new()

--- a/crates/core/benches/recommend.rs
+++ b/crates/core/benches/recommend.rs
@@ -104,6 +104,14 @@ fn bench_backends(c: &mut Criterion) {
         });
     }
 
+    #[cfg(feature = "simd")]
+    {
+        let si = yahtzee_core::linalg::SimdBackend::new();
+        group.bench_function("simd", |b| {
+            b.iter(|| black_box(scores.state_value_with(black_box(state), &si)))
+        });
+    }
+
     group.finish();
 }
 

--- a/crates/core/benches/recommend.rs
+++ b/crates/core/benches/recommend.rs
@@ -17,7 +17,9 @@ use std::hint::black_box;
 use std::sync::LazyLock;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use yahtzee_core::{dice_to_counts, recommend, Scores, State, StateInput};
+use yahtzee_core::{
+    dice_to_counts, recommend, NdarrayBackend, Scores, State, StateInput,
+};
 
 static SHARED_SCORES: LazyLock<Scores> = LazyLock::new(Scores::new);
 
@@ -78,5 +80,38 @@ fn bench_with_turn_ev(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_state_values, bench_recommend, bench_with_turn_ev);
+/// Side-by-side comparison of `LinalgBackend` impls on the same per-state
+/// EV path. NdarrayBackend is the default; whether it dispatches GEMV through
+/// `matrixmultiply` or OpenBLAS is a Cargo-feature decision (`--features blas`),
+/// so this group really compares "current ndarray build vs. faer". Run with
+/// `cargo bench -p yahtzee-core --features faer` to include FaerBackend.
+fn bench_backends(c: &mut Criterion) {
+    let scores = &*SHARED_SCORES;
+    let state = State::default();
+
+    let mut group = c.benchmark_group("state_value/backends");
+
+    let nd = NdarrayBackend;
+    group.bench_function("ndarray", |b| {
+        b.iter(|| black_box(scores.state_value_with(black_box(state), &nd)))
+    });
+
+    #[cfg(feature = "faer")]
+    {
+        let fa = yahtzee_core::linalg::FaerBackend::new();
+        group.bench_function("faer", |b| {
+            b.iter(|| black_box(scores.state_value_with(black_box(state), &fa)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_state_values,
+    bench_recommend,
+    bench_with_turn_ev,
+    bench_backends,
+);
 criterion_main!(benches);

--- a/crates/core/examples/cuda_smoke.rs
+++ b/crates/core/examples/cuda_smoke.rs
@@ -17,7 +17,7 @@ fn main() {
     println!("CUDA context + table upload: {:.1} ms", t0.elapsed().as_secs_f64() * 1000.0);
 
     let t1 = Instant::now();
-    let scores = Scores::new_with(&backend);
+    let scores = Scores::new_with(&backend).expect("CUDA build failed");
     let elapsed = t1.elapsed();
     let ev = scores.state_value(State::default());
     println!(

--- a/crates/core/examples/cuda_smoke.rs
+++ b/crates/core/examples/cuda_smoke.rs
@@ -1,0 +1,40 @@
+//! CUDA wiring smoke test. Initializes [`CudaBuildBackend`], runs the full DP
+//! fill via `Scores::new_with`, and asserts the default-state EV matches the
+//! known good value (~254.5897). With the skeleton's CPU-fallback
+//! `compute_level`, this just proves the cudarc context / table uploads work
+//! and the feature-gated wiring compiles into a runnable binary. With the
+//! real kernels in place, this becomes the correctness smoke test.
+//!
+//! Run with `cargo run -p yahtzee-core --release --example cuda_smoke --features cuda`.
+
+#[cfg(feature = "cuda")]
+fn main() {
+    use std::time::Instant;
+    use yahtzee_core::{linalg::cuda::CudaBuildBackend, Scores, State};
+
+    let t0 = Instant::now();
+    let backend = CudaBuildBackend::new().expect("CUDA init failed");
+    println!("CUDA context + table upload: {:.1} ms", t0.elapsed().as_secs_f64() * 1000.0);
+
+    let t1 = Instant::now();
+    let scores = Scores::new_with(&backend);
+    let elapsed = t1.elapsed();
+    let ev = scores.state_value(State::default());
+    println!(
+        "Scores::new_with(CudaBuildBackend) elapsed_ms={:.1} default_ev={ev:.4}",
+        elapsed.as_secs_f64() * 1000.0
+    );
+
+    let want = 254.5896;
+    assert!(
+        (ev - want).abs() < 1e-3,
+        "default-state EV diverged: got {ev}, want ~{want}",
+    );
+    println!("OK");
+}
+
+#[cfg(not(feature = "cuda"))]
+fn main() {
+    eprintln!("Build with --features cuda to run this example.");
+    std::process::exit(1);
+}

--- a/crates/core/examples/time_build_naive.rs
+++ b/crates/core/examples/time_build_naive.rs
@@ -1,0 +1,20 @@
+//! Times `Scores::new_with(&CpuBuildBackendWith(NaiveBackend))`. Companion to
+//! `time_build` (default ndarray) and `cuda_smoke` (CUDA). Used to land my
+//! prediction-vs-reality numbers when adding `NaiveBackend`.
+
+use std::time::Instant;
+
+use yahtzee_core::{CpuBuildBackendWith, NaiveBackend, Scores, State};
+
+fn main() {
+    let threads = std::env::var("RAYON_NUM_THREADS").unwrap_or_else(|_| "default".to_string());
+    let backend = CpuBuildBackendWith(NaiveBackend);
+    let t0 = Instant::now();
+    let scores = Scores::new_with(&backend).expect("naive build is infallible");
+    let elapsed = t0.elapsed();
+    let ev = scores.state_value(State::default());
+    println!(
+        "threads={threads} backend=naive elapsed_ms={:.1} default_ev={ev:.4}",
+        elapsed.as_secs_f64() * 1000.0
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,7 @@ pub use recommend::{
 };
 
 pub mod linalg;
-pub use linalg::{LinalgBackend, NdarrayBackend};
+pub use linalg::{BuildBackend, CpuBuildBackend, LinalgBackend, NdarrayBackend};
 
 #[cfg(test)]
 mod proptests;
@@ -388,6 +388,71 @@ pub struct Scores {
     valid_states: Box<[u64]>,
 }
 
+/// Per-state entry-actions table: `(13, 252)` of `score + V(child)` for valid
+/// `(action, final_dice)` pairs, 0 otherwise. The first thing the per-state
+/// EV walk computes; what `state_value_with` / `values_with` fold over to get
+/// `third_dice`. Free function over a raw `&[f32]` state-scores buffer so it
+/// can be called from a [`BuildBackend`] impl that doesn't hold a `Scores`.
+pub fn entry_actions_array(state: State, state_scores: &[f32]) -> Array2<f32> {
+    Array2::from_shape_fn((13, 252), |(action_idx, dice_idx)| {
+        let action = EntryAction::from_bits(1 << action_idx).unwrap();
+        if state.is_valid_action(action) {
+            let (score, child) = state.score_and_child(action, dice_idx as u8);
+            let child_idx: usize = child.into();
+            score + state_scores[child_idx]
+        } else {
+            0_f32
+        }
+    })
+}
+
+/// Overall expected final score from `state` under optimal play, given the
+/// `state_scores` DP buffer. Free-function form of [`Scores::state_value_with`]:
+/// the per-state pipeline that [`BuildBackend`] impls call from inside their
+/// `compute_level`.
+pub fn state_value_with<B: LinalgBackend>(
+    state: State,
+    state_scores: &[f32],
+    backend: &B,
+) -> f32 {
+    let entry_actions = entry_actions_array(state, state_scores);
+    let third_dice = entry_actions.fold_axis(Axis(0), 0_f32, |acc, v| acc.max(*v));
+    let second_keepers = backend.keepers_from_dice(&third_dice);
+    let second_dice = backend.dice_from_keepers(&second_keepers);
+    let first_keepers = backend.keepers_from_dice(&second_dice);
+    let first_dice = backend.dice_from_keepers(&first_keepers);
+    backend.initial_roll_ev(&first_dice)
+}
+
+/// Materialize an [`ExpectedValues`] for `state` against the `state_scores`
+/// DP buffer. Free-function form of [`Scores::values_with`]; same math as
+/// [`state_value_with`] but keeps the per-roll intermediate arrays the
+/// recommendation API needs.
+pub fn values_with<B: LinalgBackend>(
+    state: State,
+    state_scores: &[f32],
+    backend: &B,
+) -> ExpectedValues {
+    let entry_actions = entry_actions_array(state, state_scores);
+    let third_dice = entry_actions.fold_axis(Axis(0), 0_f32, |acc, v| acc.max(*v));
+    let second_keepers = backend.keepers_from_dice(&third_dice);
+    let second_dice = backend.dice_from_keepers(&second_keepers);
+    let first_keepers = backend.keepers_from_dice(&second_dice);
+    let first_dice = backend.dice_from_keepers(&first_keepers);
+    let value = backend.initial_roll_ev(&first_dice);
+
+    ExpectedValues {
+        entry_actions,
+        third_dice,
+        second_keepers,
+        second_dice,
+        first_keepers,
+        first_dice,
+        value,
+        state,
+    }
+}
+
 impl Scores {
     // `Default::default()` traditionally implies a cheap construction;
     // `Scores::new()` runs the entire DP and takes ~22s in tests / minutes at
@@ -396,6 +461,15 @@ impl Scores {
     // startup; only the `build` subcommand and tests instantiate fresh.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Scores {
+        Scores::new_with(&CpuBuildBackend)
+    }
+
+    /// Build a [`Scores`] table using a caller-provided [`BuildBackend`].
+    ///
+    /// `Scores::new()` calls this with [`CpuBuildBackend`] (rayon over the
+    /// per-state pipeline). To use the GPU, build with the `cuda` feature
+    /// and pass `&linalg::cuda::CudaBuildBackend::new()?` here.
+    pub fn new_with<B: BuildBackend>(backend: &B) -> Scores {
         let state_scores = Array1::zeros(NUM_STATES as usize);
         let valid_states = vec![0_u64; VALID_STATES_WORDS].into_boxed_slice();
         let mut scores = Scores {
@@ -403,33 +477,72 @@ impl Scores {
             valid_states,
         };
         scores.set_valid_states();
-        scores.set_scores();
+        scores.set_scores(backend);
         scores
     }
 
-    fn set_scores(&mut self) {
-        // We go level-by-level, bottom to top, for correctness when multiprocessing
+    fn set_scores<B: BuildBackend>(&mut self, backend: &B) {
+        // Bottom-up by level (most filled entries first) so each level only
+        // reads strictly-higher-level state scores. Within a level, all
+        // states are independent — that's the parallelism the BuildBackend
+        // exploits (rayon on CPU, kernel batch on GPU).
+        let trace = std::env::var("YAHTZEE_TRACE_LEVELS").ok().is_some();
         for level in (0..NUM_ENTRY_ACTIONS).rev() {
-            let mut new_scores = vec![0_f32; NUM_STATES as usize];
+            let t_collect = std::time::Instant::now();
+            let states = self.collect_states_at_level(level as usize);
+            let collect_ms = t_collect.elapsed().as_secs_f64() * 1000.0;
+            if states.is_empty() {
+                continue;
+            }
 
-            new_scores
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(state_idx, score)| {
-                    let state: State = state_idx.into();
-                    let state_level = state.level();
-                    if self.valid_state(state) && state_level == level as usize {
-                        *score = self.state_value(state);
-                    }
-                });
+            let t_compute = std::time::Instant::now();
+            let evs = backend.compute_level(&states, self.state_scores_slice());
+            let compute_ms = t_compute.elapsed().as_secs_f64() * 1000.0;
 
-            // write this level's scores
-            for (score_idx, score) in new_scores.into_iter().enumerate() {
-                if score > 0_f32 {
-                    self.state_scores[score_idx] = score;
-                }
+            // Write this level's EVs back into the DP buffer. Subsequent
+            // (lower) levels read these.
+            let t_write = std::time::Instant::now();
+            for (state, ev) in states.iter().zip(evs.iter()) {
+                self.state_scores[usize::from(*state)] = *ev;
+            }
+            let write_ms = t_write.elapsed().as_secs_f64() * 1000.0;
+
+            if trace {
+                eprintln!(
+                    "level={level:>2} batch={:>6} collect={collect_ms:>6.1}ms compute={compute_ms:>7.1}ms write={write_ms:>5.1}ms",
+                    states.len()
+                );
             }
         }
+    }
+
+    /// All valid states at exactly the given DP level (`level` = number of
+    /// entries filled). Returned in `usize`-encoded ascending order; the
+    /// `BuildBackend` doesn't depend on the order, but a stable order makes
+    /// debugging easier.
+    fn collect_states_at_level(&self, level: usize) -> Vec<State> {
+        // Parallel filter is cheap (tens of ms across all 13 levels) and not
+        // worth optimizing further; the inner DP per state dominates.
+        (0..NUM_STATES as usize)
+            .into_par_iter()
+            .filter_map(|idx| {
+                let state: State = idx.into();
+                if self.valid_state(state) && state.level() == level {
+                    Some(state)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Read-only view of the DP buffer. The CPU build backend hands this to
+    /// each per-state worker; the CUDA backend uploads it to device memory
+    /// once per level.
+    pub fn state_scores_slice(&self) -> &[f32] {
+        self.state_scores
+            .as_slice()
+            .expect("state_scores is contiguous")
     }
 
     /// Overall expected final score from `state` under optimal play. This is
@@ -447,13 +560,7 @@ impl Scores {
     /// (matrixmultiply, BLAS, faer, …) without changing the rest of the
     /// pipeline. Production callers want [`Scores::state_value`].
     pub fn state_value_with<B: LinalgBackend>(&self, state: State, backend: &B) -> f32 {
-        let entry_actions = self.entry_actions_array(state);
-        let third_dice = entry_actions.fold_axis(Axis(0), 0_f32, |acc, v| acc.max(*v));
-        let second_keepers = backend.keepers_from_dice(&third_dice);
-        let second_dice = backend.dice_from_keepers(&second_keepers);
-        let first_keepers = backend.keepers_from_dice(&second_dice);
-        let first_dice = backend.dice_from_keepers(&first_keepers);
-        backend.initial_roll_ev(&first_dice)
+        state_value_with(state, self.state_scores_slice(), backend)
     }
 
     pub fn values(&self, state: State) -> ExpectedValues {
@@ -462,47 +569,7 @@ impl Scores {
 
     /// Like [`Scores::values`] but with a caller-provided [`LinalgBackend`].
     pub fn values_with<B: LinalgBackend>(&self, state: State, backend: &B) -> ExpectedValues {
-        // Overall EV of each (action, final dice) pair: `score + V(child)` for
-        // valid actions, 0 for invalid. Read by the per-entry EV API.
-        let entry_actions = self.entry_actions_array(state);
-
-        // Value of each roll-3 dice combo: max action overall EV.
-        let third_dice = entry_actions.fold_axis(Axis(0), 0_f32, |acc, v| acc.max(*v));
-
-        // Value of each roll-2 keeper / roll-2 dice / roll-1 keeper / roll-1
-        // dice — alternating "max over allowed keepers" and "expectation over
-        // re-roll outcomes".
-        let second_keepers = backend.keepers_from_dice(&third_dice);
-        let second_dice = backend.dice_from_keepers(&second_keepers);
-        let first_keepers = backend.keepers_from_dice(&second_dice);
-        let first_dice = backend.dice_from_keepers(&first_keepers);
-
-        // Marginal over the initial-roll distribution gives overall state EV.
-        let value = backend.initial_roll_ev(&first_dice);
-
-        ExpectedValues {
-            entry_actions,
-            third_dice,
-            second_keepers,
-            second_dice,
-            first_keepers,
-            first_dice,
-            value,
-            state,
-        }
-    }
-
-    fn entry_actions_array(&self, state: State) -> Array2<f32> {
-        Array2::from_shape_fn((13, 252), |(action_idx, dice_idx)| {
-            let action = EntryAction::from_bits(1 << action_idx).unwrap();
-            if state.is_valid_action(action) {
-                let (score, child) = state.score_and_child(action, dice_idx as u8);
-                let child_idx: usize = child.into();
-                score + self.state_scores[child_idx]
-            } else {
-                0_f32
-            }
-        })
+        values_with(state, self.state_scores_slice(), backend)
     }
 
     fn set_valid_states(&mut self) {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -461,15 +461,24 @@ impl Scores {
     // startup; only the `build` subcommand and tests instantiate fresh.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Scores {
-        Scores::new_with(&CpuBuildBackend)
+        // CpuBuildBackend's Error type is `Infallible`, so the unwrap is
+        // statically guaranteed not to panic. We can't write a literal
+        // `match {}` because `Infallible` has no inhabitants and the match
+        // would still need to satisfy the return type.
+        match Scores::new_with(&CpuBuildBackend) {
+            Ok(s) => s,
+            Err(e) => match e {},
+        }
     }
 
     /// Build a [`Scores`] table using a caller-provided [`BuildBackend`].
     ///
     /// `Scores::new()` calls this with [`CpuBuildBackend`] (rayon over the
-    /// per-state pipeline). To use the GPU, build with the `cuda` feature
-    /// and pass `&linalg::cuda::CudaBuildBackend::new()?` here.
-    pub fn new_with<B: BuildBackend>(backend: &B) -> Scores {
+    /// per-state pipeline) and unwraps the `Infallible` result. GPU
+    /// backends can fail (driver errors, out-of-memory, kernel launch
+    /// failure) — call this directly with `&CudaBuildBackend` and handle
+    /// the error.
+    pub fn new_with<B: BuildBackend>(backend: &B) -> Result<Scores, B::Error> {
         let state_scores = Array1::zeros(NUM_STATES as usize);
         let valid_states = vec![0_u64; VALID_STATES_WORDS].into_boxed_slice();
         let mut scores = Scores {
@@ -477,11 +486,11 @@ impl Scores {
             valid_states,
         };
         scores.set_valid_states();
-        scores.set_scores(backend);
-        scores
+        scores.set_scores(backend)?;
+        Ok(scores)
     }
 
-    fn set_scores<B: BuildBackend>(&mut self, backend: &B) {
+    fn set_scores<B: BuildBackend>(&mut self, backend: &B) -> Result<(), B::Error> {
         // Bottom-up by level (most filled entries first) so each level only
         // reads strictly-higher-level state scores. Within a level, all
         // states are independent — that's the parallelism the BuildBackend
@@ -496,7 +505,7 @@ impl Scores {
             }
 
             let t_compute = std::time::Instant::now();
-            let evs = backend.compute_level(&states, self.state_scores_slice());
+            let evs = backend.compute_level(&states, self.state_scores_slice())?;
             let compute_ms = t_compute.elapsed().as_secs_f64() * 1000.0;
 
             // Write this level's EVs back into the DP buffer. Subsequent
@@ -514,6 +523,7 @@ impl Scores {
                 );
             }
         }
+        Ok(())
     }
 
     /// All valid states at exactly the given DP level (`level` = number of

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,10 @@ pub use recommend::{
 };
 
 pub mod linalg;
-pub use linalg::{BuildBackend, CpuBuildBackend, LinalgBackend, NdarrayBackend};
+pub use linalg::{
+    BuildBackend, CpuBuildBackend, CpuBuildBackendWith, LinalgBackend, NaiveBackend,
+    NdarrayBackend,
+};
 
 #[cfg(test)]
 mod proptests;
@@ -1076,6 +1079,23 @@ mod tests {
         let scores = shared_scores();
         let expected_value = scores.state_scores[default_idx];
         assert!((expected_value - 254.5896).abs() < 0.0001);
+    }
+
+    /// NaiveBackend (scalar `for` loops, no ndarray ops) should produce the
+    /// same default-state EV as NdarrayBackend (matrixmultiply-backed
+    /// `.dot()`), modulo float reordering. This is the most independent
+    /// cross-check we have, since the other backends share matrix
+    /// machinery; if these two disagree something is wrong.
+    #[test]
+    fn test_naive_backend_matches() {
+        let scores = shared_scores();
+        let state = State::default();
+        let nd = scores.state_value_with(state, &NdarrayBackend);
+        let nv = scores.state_value_with(state, &NaiveBackend);
+        assert!(
+            (nd - nv).abs() < 0.001,
+            "ndarray={nd} naive={nv} differ by more than 1e-3"
+        );
     }
 
     /// FaerBackend should produce the same default-state EV as NdarrayBackend

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1018,6 +1018,21 @@ mod tests {
         );
     }
 
+    /// Same as `test_faer_backend_matches` for the SIMD backend. Run with
+    /// `cargo test --features simd ...`.
+    #[cfg(feature = "simd")]
+    #[test]
+    fn test_simd_backend_matches() {
+        let scores = shared_scores();
+        let state = State::default();
+        let nd = scores.state_value_with(state, &NdarrayBackend);
+        let si = scores.state_value_with(state, &linalg::SimdBackend::new());
+        assert!(
+            (nd - si).abs() < 0.001,
+            "ndarray={nd} simd={si} differ by more than 1e-3"
+        );
+    }
+
     /// State for joker-rule tests: Yahtzee box filled and Threes filled, so a
     /// rolled three-yahtzee triggers the joker rule for any lower category.
     /// `yahtzee_bonus_eligible: false` keeps the +100 bonus out of the picture.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -371,15 +371,15 @@ mod math {
 const VALID_STATES_WORDS: usize = (NUM_STATES as usize).div_ceil(64);
 
 /// Per-keeper expected dice-value: for each keeper `k`, sum over re-roll
-/// outcomes `d` of `P(k → d) * dice_values[d]`.
+/// outcomes `d` of `P(k → d) * dice_values[d]`. This is exactly the GEMV
+/// `KEEPERS_TO_DICE_PROBABILITIES (462x252) * dice_values (252)`, so we
+/// dispatch through `ndarray::Array2::dot`. With the `blas` feature off,
+/// that uses ndarray's default `matrixmultiply` backend (pure-Rust SIMD);
+/// with `blas` on, it goes to `cblas_sgemv`. Called twice per state via
+/// `Scores::values` / `Scores::state_value`, so it's the GEMV worth
+/// optimizing.
 fn keepers_from_dice(dice_values: &Array1<f32>) -> Array1<f32> {
-    let mut keepers: Array1<f32> = Array1::zeros(NUM_KEEPERS as usize);
-    Zip::from(&mut keepers)
-        .and(KEEPERS_TO_DICE_PROBABILITIES.rows())
-        .for_each(|avg, row| {
-            *avg = (&row * dice_values).sum();
-        });
-    keepers
+    KEEPERS_TO_DICE_PROBABILITIES.dot(dice_values)
 }
 
 /// Per-dice "best keeper" value: for each dice combo `d`, max over keepers

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1001,6 +1001,23 @@ mod tests {
         assert!((expected_value - 254.5896).abs() < 0.0001);
     }
 
+    /// FaerBackend should produce the same default-state EV as NdarrayBackend
+    /// (the default), modulo float reordering. Uses the precomputed `state_scores`
+    /// table (built via the default backend) as the substrate, and only swaps
+    /// the per-state EV computation. Run with `cargo test --features faer ...`.
+    #[cfg(feature = "faer")]
+    #[test]
+    fn test_faer_backend_matches() {
+        let scores = shared_scores();
+        let state = State::default();
+        let nd = scores.state_value_with(state, &NdarrayBackend);
+        let fa = scores.state_value_with(state, &linalg::FaerBackend::new());
+        assert!(
+            (nd - fa).abs() < 0.001,
+            "ndarray={nd} faer={fa} differ by more than 1e-3"
+        );
+    }
+
     /// State for joker-rule tests: Yahtzee box filled and Threes filled, so a
     /// rolled three-yahtzee triggers the joker rule for any lower category.
     /// `yahtzee_bonus_eligible: false` keeps the +100 bonus out of the picture.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,12 @@
 //! callers want [`recommend::recommend`] rather than the lower-level types
 //! here.
 
+// Anchor `blas-src` so the BLAS provider's symbols (e.g. `cblas_sdot`) survive
+// `--as-needed` link-time DCE. Without this, ndarray's `.dot()` calls fail to
+// link with `--features blas`. Has no runtime effect; pure link-time glue.
+#[cfg(feature = "blas")]
+extern crate blas_src;
+
 use std::collections::HashMap;
 use std::convert::From;
 use std::fmt;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,7 +29,6 @@ use std::fmt::Display;
 use std::sync::LazyLock;
 
 use bitflags::bitflags;
-use ndarray::Zip;
 use ndarray::prelude::*;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -39,6 +38,9 @@ pub use recommend::{
     build_state, counts_to_faces, dice_to_counts, recommend, EntryRec, KeeperRec, Recommendation,
     StateInput,
 };
+
+pub mod linalg;
+pub use linalg::{LinalgBackend, NdarrayBackend};
 
 #[cfg(test)]
 mod proptests;
@@ -106,8 +108,12 @@ static DICE_IDX_LOOKUP: LazyLock<HashMap<DiceCounts, usize>> = LazyLock::new(mat
 static IDX_KEEPERS_LOOKUP: LazyLock<HashMap<usize, DiceCounts>> =
     LazyLock::new(math::idx_keepers_lookup);
 static DICE_AND_ENTRY_SCORES: LazyLock<Array2<u8>> = LazyLock::new(math::dice_and_entry_scores);
-static DICE_TO_ALLOWED_KEEPERS: LazyLock<Array2<f32>> = LazyLock::new(math::dice_to_keepers);
-static KEEPERS_TO_DICE_PROBABILITIES: LazyLock<Array2<f32>> = LazyLock::new(math::keepers_to_dice);
+// `pub(crate)` so the `linalg` submodule can read them; not part of the
+// public API.
+pub(crate) static DICE_TO_ALLOWED_KEEPERS: LazyLock<Array2<f32>> =
+    LazyLock::new(math::dice_to_keepers);
+pub(crate) static KEEPERS_TO_DICE_PROBABILITIES: LazyLock<Array2<f32>> =
+    LazyLock::new(math::keepers_to_dice);
 
 mod math {
     use super::EntryAction;
@@ -370,38 +376,11 @@ mod math {
 // Packed bitset over NUM_STATES entries (16_384 u64 words = 128 KiB).
 const VALID_STATES_WORDS: usize = (NUM_STATES as usize).div_ceil(64);
 
-/// Per-keeper expected dice-value: for each keeper `k`, sum over re-roll
-/// outcomes `d` of `P(k → d) * dice_values[d]`. This is exactly the GEMV
-/// `KEEPERS_TO_DICE_PROBABILITIES (462x252) * dice_values (252)`, so we
-/// dispatch through `ndarray::Array2::dot`. With the `blas` feature off,
-/// that uses ndarray's default `matrixmultiply` backend (pure-Rust SIMD);
-/// with `blas` on, it goes to `cblas_sgemv`. Called twice per state via
-/// `Scores::values` / `Scores::state_value`, so it's the GEMV worth
-/// optimizing.
-fn keepers_from_dice(dice_values: &Array1<f32>) -> Array1<f32> {
-    KEEPERS_TO_DICE_PROBABILITIES.dot(dice_values)
-}
-
-/// Per-dice "best keeper" value: for each dice combo `d`, max over keepers
-/// valid for `d` of `keeper_values[k]`. (`DICE_TO_ALLOWED_KEEPERS` is an
-/// indicator matrix: 1 where the keeper is achievable from `d`, 0 elsewhere,
-/// so element-wise multiply masks the invalid keepers to 0 before the max.)
-fn dice_from_keepers(keeper_values: &Array1<f32>) -> Array1<f32> {
-    let mut dice: Array1<f32> = Array1::zeros(NUM_DICE_COMBINATIONS as usize);
-    Zip::from(&mut dice)
-        .and(DICE_TO_ALLOWED_KEEPERS.rows())
-        .for_each(|val, mask_row| {
-            *val = (&mask_row * keeper_values).fold(0_f32, |acc, elem| acc.max(*elem));
-        });
-    dice
-}
-
-/// Initial-roll distribution: row 0 of `KEEPERS_TO_DICE_PROBABILITIES` is the
-/// "kept nothing → roll 5 fresh dice" row, which is the marginal we want for
-/// turning per-dice values into the state EV.
-fn first_roll_probabilities() -> ndarray::ArrayView1<'static, f32> {
-    KEEPERS_TO_DICE_PROBABILITIES.index_axis(Axis(0), 0)
-}
+// The keepers_from_dice / dice_from_keepers / initial-roll-dot operations
+// previously implemented as free functions here now live on the
+// `LinalgBackend` trait in `crate::linalg`. `Scores::state_value` /
+// `Scores::values` call the default `NdarrayBackend` and behave identically;
+// the `_with` variants accept any backend for benchmarking.
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scores {
@@ -460,16 +439,29 @@ impl Scores {
     /// underlying math is identical, so the perf delta is small (skips a
     /// struct construction); use this when you only need the EV.
     pub fn state_value(&self, state: State) -> f32 {
+        self.state_value_with(state, &NdarrayBackend)
+    }
+
+    /// Like [`Scores::state_value`] but with a caller-provided
+    /// [`LinalgBackend`]. Used by benches to compare GEMV implementations
+    /// (matrixmultiply, BLAS, faer, …) without changing the rest of the
+    /// pipeline. Production callers want [`Scores::state_value`].
+    pub fn state_value_with<B: LinalgBackend>(&self, state: State, backend: &B) -> f32 {
         let entry_actions = self.entry_actions_array(state);
         let third_dice = entry_actions.fold_axis(Axis(0), 0_f32, |acc, v| acc.max(*v));
-        let second_keepers = keepers_from_dice(&third_dice);
-        let second_dice = dice_from_keepers(&second_keepers);
-        let first_keepers = keepers_from_dice(&second_dice);
-        let first_dice = dice_from_keepers(&first_keepers);
-        first_roll_probabilities().dot(&first_dice)
+        let second_keepers = backend.keepers_from_dice(&third_dice);
+        let second_dice = backend.dice_from_keepers(&second_keepers);
+        let first_keepers = backend.keepers_from_dice(&second_dice);
+        let first_dice = backend.dice_from_keepers(&first_keepers);
+        backend.initial_roll_ev(&first_dice)
     }
 
     pub fn values(&self, state: State) -> ExpectedValues {
+        self.values_with(state, &NdarrayBackend)
+    }
+
+    /// Like [`Scores::values`] but with a caller-provided [`LinalgBackend`].
+    pub fn values_with<B: LinalgBackend>(&self, state: State, backend: &B) -> ExpectedValues {
         // Overall EV of each (action, final dice) pair: `score + V(child)` for
         // valid actions, 0 for invalid. Read by the per-entry EV API.
         let entry_actions = self.entry_actions_array(state);
@@ -480,13 +472,13 @@ impl Scores {
         // Value of each roll-2 keeper / roll-2 dice / roll-1 keeper / roll-1
         // dice — alternating "max over allowed keepers" and "expectation over
         // re-roll outcomes".
-        let second_keepers = keepers_from_dice(&third_dice);
-        let second_dice = dice_from_keepers(&second_keepers);
-        let first_keepers = keepers_from_dice(&second_dice);
-        let first_dice = dice_from_keepers(&first_keepers);
+        let second_keepers = backend.keepers_from_dice(&third_dice);
+        let second_dice = backend.dice_from_keepers(&second_keepers);
+        let first_keepers = backend.keepers_from_dice(&second_dice);
+        let first_dice = backend.dice_from_keepers(&first_keepers);
 
         // Marginal over the initial-roll distribution gives overall state EV.
-        let value = first_roll_probabilities().dot(&first_dice);
+        let value = backend.initial_roll_ev(&first_dice);
 
         ExpectedValues {
             entry_actions,

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -77,3 +77,83 @@ impl LinalgBackend for NdarrayBackend {
         KEEPERS_TO_DICE_PROBABILITIES.row(0).dot(first_dice)
     }
 }
+
+/// faer-based backend (opt-in via `--features faer`). Uses faer's GEMV for
+/// `keepers_from_dice` and scalar dot for `initial_roll_ev`. The masked-max
+/// in `dice_from_keepers` isn't a linear op so faer doesn't help — we reuse
+/// the same Zip-based implementation as `NdarrayBackend`.
+///
+/// Holds preprocessed `faer::Mat` / `faer::Col` copies of the static
+/// probability tables, built once at `FaerBackend::new()` time.
+#[cfg(feature = "faer")]
+pub use faer_impl::FaerBackend;
+
+#[cfg(feature = "faer")]
+mod faer_impl {
+    use super::{LinalgBackend, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES,
+        NUM_DICE_COMBINATIONS};
+    use faer::{Col, Mat};
+    use ndarray::{Array1, Zip};
+
+    pub struct FaerBackend {
+        // (462, 252) preprocessed copy of KEEPERS_TO_DICE_PROBABILITIES.
+        keepers_to_dice: Mat<f32>,
+        // Length-252 row-0 of the same matrix (initial-roll distribution).
+        first_roll: Col<f32>,
+    }
+
+    impl FaerBackend {
+        pub fn new() -> Self {
+            let nd = &*KEEPERS_TO_DICE_PROBABILITIES;
+            let (rows, cols) = nd.dim();
+            let keepers_to_dice = Mat::from_fn(rows, cols, |i, j| nd[(i, j)]);
+            let first_roll = Col::from_fn(cols, |j| nd[(0, j)]);
+            Self {
+                keepers_to_dice,
+                first_roll,
+            }
+        }
+    }
+
+    impl Default for FaerBackend {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl LinalgBackend for FaerBackend {
+        #[inline]
+        fn keepers_from_dice(&self, dice_values: &Array1<f32>) -> Array1<f32> {
+            // Borrow ndarray slice as a faer column without copying.
+            let slice = dice_values.as_slice().expect("dice_values contiguous");
+            let dice_col = faer::ColRef::from_slice(slice);
+
+            // GEMV via faer's Mul overload (Mat * Col -> Col).
+            let out: Col<f32> = &self.keepers_to_dice * dice_col;
+
+            // Convert faer Col -> ndarray Array1 (one allocation; same shape as
+            // ndarray's `.dot()` path, which also returns an owned Array1).
+            Array1::from_iter(out.iter().copied())
+        }
+
+        #[inline]
+        fn dice_from_keepers(&self, keeper_values: &Array1<f32>) -> Array1<f32> {
+            // Masked max-reduction; faer doesn't help. Identical to NdarrayBackend.
+            let mut dice: Array1<f32> = Array1::zeros(NUM_DICE_COMBINATIONS as usize);
+            Zip::from(&mut dice)
+                .and(DICE_TO_ALLOWED_KEEPERS.rows())
+                .for_each(|val, mask_row| {
+                    *val = (&mask_row * keeper_values).fold(0_f32, |acc, elem| acc.max(*elem));
+                });
+            dice
+        }
+
+        #[inline]
+        fn initial_roll_ev(&self, first_dice: &Array1<f32>) -> f32 {
+            let slice = first_dice.as_slice().expect("first_dice contiguous");
+            let v = faer::ColRef::from_slice(slice);
+            // Inner product via faer's column-vs-column dot.
+            (0..v.nrows()).map(|i| self.first_roll[i] * v[i]).sum()
+        }
+    }
+}

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -99,11 +99,22 @@ impl LinalgBackend for NdarrayBackend {
 /// the existing per-state pipeline; it's morally identical to the in-line
 /// loop the DP previously used.
 ///
-/// A future GPU implementation lives behind the `cuda` Cargo feature and
-/// owns the full batched pipeline internally (custom kernels +
-/// cuBLAS sgemm), so it can amortize kernel-launch overhead across all
-/// states at a level instead of paying it per state.
+/// The CUDA implementation lives behind the `cuda` Cargo feature and owns
+/// the full batched pipeline internally (custom kernels + cuBLAS sgemm),
+/// so it can amortize kernel-launch overhead across all states at a level
+/// instead of paying it per state.
+///
+/// `compute_level` is fallible because GPU backends can fail mid-build
+/// (out-of-memory, driver disconnect, kernel launch error, etc.). The
+/// associated [`Self::Error`] type is `std::convert::Infallible` for CPU
+/// backends and a richer error enum for GPU backends.
 pub trait BuildBackend: Send + Sync {
+    /// Errors a `compute_level` call can raise. CPU backends typically use
+    /// `std::convert::Infallible` (which lets callers `.unwrap()` knowing
+    /// the call cannot fail at runtime); GPU backends use a richer enum
+    /// surfacing driver / cuBLAS / kernel errors.
+    type Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static;
+
     /// Compute the overall EV of every state in `states`. The returned
     /// vector is in the same order as the input. `state_scores` is the
     /// (read-only) DP buffer holding EVs for already-computed levels —
@@ -111,7 +122,11 @@ pub trait BuildBackend: Send + Sync {
     /// of `state_scores` they read are at strictly higher levels (more
     /// entries filled), so the contents at the level-being-computed don't
     /// matter.
-    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32>;
+    fn compute_level(
+        &self,
+        states: &[State],
+        state_scores: &[f32],
+    ) -> Result<Vec<f32>, Self::Error>;
 }
 
 /// Default [`BuildBackend`] impl: rayon `par_iter` over the per-state EV
@@ -121,12 +136,22 @@ pub trait BuildBackend: Send + Sync {
 pub struct CpuBuildBackend;
 
 impl BuildBackend for CpuBuildBackend {
-    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32> {
+    // Pure-CPU rayon work: no I/O, no allocation that can fail in any way
+    // we'd want to recover from. `Infallible` lets `Scores::new()` (which
+    // calls `Scores::new_with(&CpuBuildBackend)`) stay infallible without
+    // any `Result`-flavored noise at the public API.
+    type Error = std::convert::Infallible;
+
+    fn compute_level(
+        &self,
+        states: &[State],
+        state_scores: &[f32],
+    ) -> Result<Vec<f32>, Self::Error> {
         let backend = NdarrayBackend;
-        states
+        Ok(states
             .par_iter()
             .map(|state| state_value_with(*state, state_scores, &backend))
-            .collect()
+            .collect())
     }
 }
 

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -24,10 +24,24 @@
 //! `Scores::values` use. Other backends (e.g. `FaerBackend` under the `faer`
 //! feature) are typically only reached via `Scores::state_value_with` /
 //! `Scores::values_with`, which the benches use to compare apples-to-apples.
+//!
+//! There is a second, coarser-grained trait in this module: [`BuildBackend`].
+//! `LinalgBackend` is the *per-state* abstraction (one state, three GEMV/max
+//! ops). `BuildBackend` is the *per-level* abstraction: given a batch of
+//! states at the same DP level and the read-only state-scores buffer, return
+//! the EV of every state in the batch. The CPU implementation
+//! ([`CpuBuildBackend`]) is a thin rayon `par_iter` wrapper over the per-state
+//! path, so it costs nothing relative to the previous in-line loop. The
+//! coarser granularity exists so a future GPU backend can amortize kernel
+//! launches across a whole level instead of paying launch overhead per state.
 
 use ndarray::{Array1, Zip};
+use rayon::prelude::*;
 
-use crate::{DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES, NUM_DICE_COMBINATIONS};
+use crate::{
+    state_value_with, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES,
+    NUM_DICE_COMBINATIONS, State,
+};
 
 /// The three swappable linear-algebra steps in the per-state EV pipeline.
 /// Implementations should be cheap to construct (`Default::default()` is
@@ -78,6 +92,44 @@ impl LinalgBackend for NdarrayBackend {
     }
 }
 
+/// Coarser-grained "given a level's worth of states, return their EVs" trait.
+/// Used by [`crate::Scores::new_with`] to drive the level-by-level DP fill.
+///
+/// The CPU implementation ([`CpuBuildBackend`]) is a rayon `par_iter` over
+/// the existing per-state pipeline; it's morally identical to the in-line
+/// loop the DP previously used.
+///
+/// A future GPU implementation lives behind the `cuda` Cargo feature and
+/// owns the full batched pipeline internally (custom kernels +
+/// cuBLAS sgemm), so it can amortize kernel-launch overhead across all
+/// states at a level instead of paying it per state.
+pub trait BuildBackend: Send + Sync {
+    /// Compute the overall EV of every state in `states`. The returned
+    /// vector is in the same order as the input. `state_scores` is the
+    /// (read-only) DP buffer holding EVs for already-computed levels —
+    /// every state in `states` is at the same level, and the only entries
+    /// of `state_scores` they read are at strictly higher levels (more
+    /// entries filled), so the contents at the level-being-computed don't
+    /// matter.
+    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32>;
+}
+
+/// Default [`BuildBackend`] impl: rayon `par_iter` over the per-state EV
+/// path using [`NdarrayBackend`]. Behaves identically to the in-line loop
+/// `Scores::set_scores` used before the trait was extracted.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CpuBuildBackend;
+
+impl BuildBackend for CpuBuildBackend {
+    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32> {
+        let backend = NdarrayBackend;
+        states
+            .par_iter()
+            .map(|state| state_value_with(*state, state_scores, &backend))
+            .collect()
+    }
+}
+
 /// faer-based backend (opt-in via `--features faer`). Uses faer's GEMV for
 /// `keepers_from_dice` and scalar dot for `initial_roll_ev`. The masked-max
 /// in `dice_from_keepers` isn't a linear op so faer doesn't help — we reuse
@@ -97,6 +149,14 @@ pub use faer_impl::FaerBackend;
 /// columns so each row is a clean sequence of `f32x8` lanes.
 #[cfg(feature = "simd")]
 pub use simd_impl::SimdBackend;
+
+/// CUDA backend (opt-in via `--features cuda`). Implements [`BuildBackend`]
+/// (per-level batched), not [`LinalgBackend`] (per-state). See
+/// [`cuda::CudaBuildBackend`] for the gory details.
+#[cfg(feature = "cuda")]
+pub mod cuda;
+#[cfg(feature = "cuda")]
+pub use cuda::CudaBuildBackend;
 
 #[cfg(feature = "simd")]
 mod simd_impl {

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -88,6 +88,106 @@ impl LinalgBackend for NdarrayBackend {
 #[cfg(feature = "faer")]
 pub use faer_impl::FaerBackend;
 
+/// Hand-vectorized backend (opt-in via `--features simd`). Uses ndarray's
+/// `.dot()` for the GEMV and a `wide::f32x8`-based loop for the masked-max
+/// `dice_from_keepers`. The latter is the op BLAS / faer can't help with,
+/// so it's the only place new SIMD code can move the needle.
+///
+/// Holds a copy of `DICE_TO_ALLOWED_KEEPERS` row-padded to a multiple of 8
+/// columns so each row is a clean sequence of `f32x8` lanes.
+#[cfg(feature = "simd")]
+pub use simd_impl::SimdBackend;
+
+#[cfg(feature = "simd")]
+mod simd_impl {
+    use super::{LinalgBackend, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES,
+        NUM_DICE_COMBINATIONS};
+    use ndarray::Array1;
+    use wide::f32x8;
+
+    const LANES: usize = 8;
+    // 462 keepers padded up to the next multiple of 8 = 464.
+    const KEEPER_LANES: usize = ((462 + LANES - 1) / LANES) * LANES;
+
+    pub struct SimdBackend {
+        // Row-major, 252 rows × KEEPER_LANES cols, padded with 0.0.
+        mask_padded: Vec<f32>,
+    }
+
+    impl SimdBackend {
+        pub fn new() -> Self {
+            let nd = &*DICE_TO_ALLOWED_KEEPERS;
+            let (n_dice, n_keepers) = nd.dim();
+            assert_eq!(n_dice, NUM_DICE_COMBINATIONS as usize);
+            let mut mask_padded = vec![0.0_f32; n_dice * KEEPER_LANES];
+            for d in 0..n_dice {
+                for k in 0..n_keepers {
+                    mask_padded[d * KEEPER_LANES + k] = nd[(d, k)];
+                }
+                // Trailing KEEPER_LANES - n_keepers slots stay 0.0.
+            }
+            Self { mask_padded }
+        }
+    }
+
+    impl Default for SimdBackend {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl LinalgBackend for SimdBackend {
+        #[inline]
+        fn keepers_from_dice(&self, dice_values: &Array1<f32>) -> Array1<f32> {
+            // Same as NdarrayBackend; SIMD doesn't add anything ndarray's
+            // GEMV doesn't already do.
+            KEEPERS_TO_DICE_PROBABILITIES.dot(dice_values)
+        }
+
+        #[inline]
+        fn dice_from_keepers(&self, keeper_values: &Array1<f32>) -> Array1<f32> {
+            let kv = keeper_values
+                .as_slice()
+                .expect("keeper_values is contiguous");
+
+            // Copy into a length-KEEPER_LANES scratch with trailing zeros so
+            // the multiply-against-mask doesn't pick up garbage in the tail.
+            // (Mask tail is already 0; any value here would survive the
+            // 0 * x = 0 max contribution. Padding still matters because we
+            // load 8 lanes regardless.)
+            let mut padded_kv = [0.0_f32; KEEPER_LANES];
+            padded_kv[..kv.len()].copy_from_slice(kv);
+
+            let mut out: Array1<f32> = Array1::zeros(NUM_DICE_COMBINATIONS as usize);
+            // SAFETY: KEEPER_LANES is divisible by LANES; both arrays are aligned f32.
+            let kv_chunks: &[[f32; LANES]] = bytemuck::cast_slice(&padded_kv);
+
+            for d in 0..NUM_DICE_COMBINATIONS as usize {
+                let row_start = d * KEEPER_LANES;
+                let mask_row = &self.mask_padded[row_start..row_start + KEEPER_LANES];
+                let mask_chunks: &[[f32; LANES]] = bytemuck::cast_slice(mask_row);
+
+                let mut acc = f32x8::splat(0.0);
+                for (m_chunk, k_chunk) in mask_chunks.iter().zip(kv_chunks.iter()) {
+                    let m = f32x8::from(*m_chunk);
+                    let k = f32x8::from(*k_chunk);
+                    acc = acc.fast_max(m * k);
+                }
+                // wide 1.3 has no horizontal max; scalar fold over 8 lanes.
+                let lanes: [f32; LANES] = acc.into();
+                out[d] = lanes.iter().copied().fold(0.0_f32, f32::max);
+            }
+            out
+        }
+
+        #[inline]
+        fn initial_roll_ev(&self, first_dice: &Array1<f32>) -> f32 {
+            // Same as NdarrayBackend.
+            KEEPERS_TO_DICE_PROBABILITIES.row(0).dot(first_dice)
+        }
+    }
+}
+
 #[cfg(feature = "faer")]
 mod faer_impl {
     use super::{LinalgBackend, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES,

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -1,0 +1,79 @@
+//! Pluggable linear-algebra backends for the per-state EV pipeline.
+//!
+//! `Scores::state_value` and `Scores::values` walk the three-roll decision
+//! tree by alternating two shape-changing ops on the dice-value array:
+//!
+//! 1. **Per-keeper expected dice value** (`keepers_from_dice`) — a true GEMV:
+//!    `out[k] = sum_d KEEPERS_TO_DICE_PROBABILITIES[k,d] * dice_values[d]`,
+//!    shape (462, 252) × (252,) → (462,). Called twice per state.
+//! 2. **Per-dice "best valid keeper"** (`dice_from_keepers`) — a *masked*
+//!    max reduction: `out[d] = max over keepers k where DICE_TO_ALLOWED_KEEPERS[d,k] != 0
+//!    of keeper_values[k]`. Not linear; BLAS / matrixmultiply / faer can't help.
+//!    Also called twice per state.
+//!
+//! Plus a final scalar dot product against the initial-roll distribution
+//! (`initial_roll_ev`).
+//!
+//! This module abstracts those three ops behind [`LinalgBackend`] so different
+//! GEMV implementations can be benchmarked side-by-side. The trait stays
+//! narrow — Yahtzee-specific scoring (entry-action table, joker rule, upper
+//! bonus) lives in `Scores` because it's tied to the state encoding rather
+//! than dense linalg.
+//!
+//! `NdarrayBackend` is the default and is what `Scores::state_value` /
+//! `Scores::values` use. Other backends (e.g. `FaerBackend` under the `faer`
+//! feature) are typically only reached via `Scores::state_value_with` /
+//! `Scores::values_with`, which the benches use to compare apples-to-apples.
+
+use ndarray::{Array1, Zip};
+
+use crate::{DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES, NUM_DICE_COMBINATIONS};
+
+/// The three swappable linear-algebra steps in the per-state EV pipeline.
+/// Implementations should be cheap to construct (`Default::default()` is
+/// recommended where possible) and stateless or holding only preprocessed
+/// matrices; one instance can be reused across many calls.
+pub trait LinalgBackend: Send + Sync {
+    /// 252 → 462. `out[k] = sum over d of KEEPERS_TO_DICE_PROBABILITIES[k,d] * dice_values[d]`.
+    fn keepers_from_dice(&self, dice_values: &Array1<f32>) -> Array1<f32>;
+
+    /// 462 → 252. `out[d] = max over keepers k allowed for d of keeper_values[k]`.
+    fn dice_from_keepers(&self, keeper_values: &Array1<f32>) -> Array1<f32>;
+
+    /// 252 → scalar. Marginal of `first_dice` over the initial-roll distribution
+    /// (= row 0 of `KEEPERS_TO_DICE_PROBABILITIES`, the "kept nothing → roll 5
+    /// fresh dice" probabilities).
+    fn initial_roll_ev(&self, first_dice: &Array1<f32>) -> f32;
+}
+
+/// Default backend: GEMV via `ndarray::Array2::dot` (which dispatches to
+/// `matrixmultiply` by default, or to `cblas_sgemv` under `--features blas`),
+/// masked max via a hand-rolled `Zip`, and the scalar dot product via
+/// `ArrayView1::dot`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NdarrayBackend;
+
+impl LinalgBackend for NdarrayBackend {
+    #[inline]
+    fn keepers_from_dice(&self, dice_values: &Array1<f32>) -> Array1<f32> {
+        KEEPERS_TO_DICE_PROBABILITIES.dot(dice_values)
+    }
+
+    #[inline]
+    fn dice_from_keepers(&self, keeper_values: &Array1<f32>) -> Array1<f32> {
+        let mut dice: Array1<f32> = Array1::zeros(NUM_DICE_COMBINATIONS as usize);
+        Zip::from(&mut dice)
+            .and(DICE_TO_ALLOWED_KEEPERS.rows())
+            .for_each(|val, mask_row| {
+                *val = (&mask_row * keeper_values).fold(0_f32, |acc, elem| acc.max(*elem));
+            });
+        dice
+    }
+
+    #[inline]
+    fn initial_roll_ev(&self, first_dice: &Array1<f32>) -> f32 {
+        // Row 0 = "kept nothing" = initial-roll distribution over the 252
+        // five-dice combos.
+        KEEPERS_TO_DICE_PROBABILITIES.row(0).dot(first_dice)
+    }
+}

--- a/crates/core/src/linalg.rs
+++ b/crates/core/src/linalg.rs
@@ -25,6 +25,13 @@
 //! feature) are typically only reached via `Scores::state_value_with` /
 //! `Scores::values_with`, which the benches use to compare apples-to-apples.
 //!
+//! `NaiveBackend` is a bonus: a scalar-`for`-loop reference impl that reads
+//! exactly like the math in the trait docstrings. No ndarray, BLAS, faer or
+//! SIMD machinery. Useful as a meaningfully-independent oracle for tests
+//! (it shares no code with the optimized backends) and as a "honest"
+//! baseline so other backends' speedups can be quoted relative to a clear
+//! reference rather than to each other.
+//!
 //! There is a second, coarser-grained trait in this module: [`BuildBackend`].
 //! `LinalgBackend` is the *per-state* abstraction (one state, three GEMV/max
 //! ops). `BuildBackend` is the *per-level* abstraction: given a batch of
@@ -39,8 +46,8 @@ use ndarray::{Array1, Zip};
 use rayon::prelude::*;
 
 use crate::{
-    state_value_with, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES,
-    NUM_DICE_COMBINATIONS, State,
+    state_value_with, DICE_TO_ALLOWED_KEEPERS, KEEPERS_TO_DICE_PROBABILITIES, NUM_DICE_COMBINATIONS,
+    NUM_KEEPERS, State,
 };
 
 /// The three swappable linear-algebra steps in the per-state EV pipeline.
@@ -89,6 +96,91 @@ impl LinalgBackend for NdarrayBackend {
         // Row 0 = "kept nothing" = initial-roll distribution over the 252
         // five-dice combos.
         KEEPERS_TO_DICE_PROBABILITIES.row(0).dot(first_dice)
+    }
+}
+
+/// Reference impl: nested scalar `for` loops over `&[f32]` slices, no
+/// ndarray ops, no SIMD, no BLAS, no faer. Reads exactly like the math in
+/// the trait docstrings.
+///
+/// Two purposes:
+///
+/// 1. **Cross-check oracle.** The other backends all share some flavor of
+///    the same matrix machinery (ndarray's `.dot()`, with optional BLAS or
+///    SIMD speedups, or faer's GEMV) — none are *meaningfully* independent.
+///    A naive scalar loop is independent code; if it disagrees with the
+///    others by more than fp tolerance, something's wrong with one of them.
+///
+/// 2. **Calibration baseline.** Every other backend's speedup is "vs. some
+///    optimized baseline." The naive backend is the "if you'd just written
+///    the math" baseline, so the speedups can be quoted relative to *that*.
+///    At our small problem sizes (252×462 and 462×252) the constant
+///    overhead in matrixmultiply / BLAS / faer can eat their asymptotic
+///    advantage, so the gap may be smaller than you'd expect.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NaiveBackend;
+
+impl LinalgBackend for NaiveBackend {
+    #[inline]
+    fn keepers_from_dice(&self, dice_values: &Array1<f32>) -> Array1<f32> {
+        // out[k] = Σ_d KEEPERS_TO_DICE_PROBABILITIES[k, d] * dice_values[d]
+        let probs = KEEPERS_TO_DICE_PROBABILITIES
+            .as_slice()
+            .expect("KEEPERS_TO_DICE_PROBABILITIES is contiguous");
+        let dice = dice_values.as_slice().expect("dice_values is contiguous");
+        let n_d = NUM_DICE_COMBINATIONS as usize;
+        let mut out = vec![0.0_f32; NUM_KEEPERS as usize];
+        for k in 0..NUM_KEEPERS as usize {
+            let row = &probs[k * n_d..(k + 1) * n_d];
+            let mut acc = 0.0_f32;
+            for d in 0..n_d {
+                acc += row[d] * dice[d];
+            }
+            out[k] = acc;
+        }
+        Array1::from_vec(out)
+    }
+
+    #[inline]
+    fn dice_from_keepers(&self, keeper_values: &Array1<f32>) -> Array1<f32> {
+        // out[d] = max over keepers k where DICE_TO_ALLOWED_KEEPERS[d, k] != 0
+        //          of keeper_values[k]
+        let mask = DICE_TO_ALLOWED_KEEPERS
+            .as_slice()
+            .expect("DICE_TO_ALLOWED_KEEPERS is contiguous");
+        let kv = keeper_values
+            .as_slice()
+            .expect("keeper_values is contiguous");
+        let n_d = NUM_DICE_COMBINATIONS as usize;
+        let n_k = NUM_KEEPERS as usize;
+        let mut out = vec![0.0_f32; n_d];
+        for d in 0..n_d {
+            let row = &mask[d * n_k..(d + 1) * n_k];
+            let mut best = 0.0_f32;
+            for k in 0..n_k {
+                if row[k] != 0.0 && kv[k] > best {
+                    best = kv[k];
+                }
+            }
+            out[d] = best;
+        }
+        Array1::from_vec(out)
+    }
+
+    #[inline]
+    fn initial_roll_ev(&self, first_dice: &Array1<f32>) -> f32 {
+        // out = Σ_d KEEPERS_TO_DICE_PROBABILITIES[0, d] * first_dice[d]
+        let probs = KEEPERS_TO_DICE_PROBABILITIES
+            .as_slice()
+            .expect("KEEPERS_TO_DICE_PROBABILITIES is contiguous");
+        let n_d = NUM_DICE_COMBINATIONS as usize;
+        let row0 = &probs[..n_d];
+        let fd = first_dice.as_slice().expect("first_dice is contiguous");
+        let mut acc = 0.0_f32;
+        for d in 0..n_d {
+            acc += row0[d] * fd[d];
+        }
+        acc
     }
 }
 
@@ -151,6 +243,32 @@ impl BuildBackend for CpuBuildBackend {
         Ok(states
             .par_iter()
             .map(|state| state_value_with(*state, state_scores, &backend))
+            .collect())
+    }
+}
+
+/// Like [`CpuBuildBackend`], but parameterized over the [`LinalgBackend`]
+/// used inside the per-state walk. Lets benches and external callers
+/// drive a full table build through a non-default linear-algebra
+/// implementation (e.g. [`NaiveBackend`], `SimdBackend`, `FaerBackend`)
+/// without copy-pasting the rayon scaffolding.
+///
+/// `CpuBuildBackend` is exactly `CpuBuildBackendWith(NdarrayBackend)` plus
+/// a shorter name; both are kept for API ergonomics.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CpuBuildBackendWith<L: LinalgBackend>(pub L);
+
+impl<L: LinalgBackend> BuildBackend for CpuBuildBackendWith<L> {
+    type Error = std::convert::Infallible;
+
+    fn compute_level(
+        &self,
+        states: &[State],
+        state_scores: &[f32],
+    ) -> Result<Vec<f32>, Self::Error> {
+        Ok(states
+            .par_iter()
+            .map(|state| state_value_with(*state, state_scores, &self.0))
             .collect())
     }
 }

--- a/crates/core/src/linalg/cuda.rs
+++ b/crates/core/src/linalg/cuda.rs
@@ -27,7 +27,7 @@
 //! `fallback-dynamic-loading` feature). No CUDA headers or `nvcc` are
 //! required at build time, only the runtime `.so`s at run time.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use cudarc::cublas::{sys::cublasOperation_t, CudaBlas, Gemm, GemmConfig};
 use cudarc::driver::{
@@ -273,6 +273,24 @@ extern "C" __global__ void initial_roll_ev(
         out[state_b] = sdata[0];
     }
 }
+
+// Scatter the per-state EVs we just computed into the device-resident
+// `state_scores` buffer at the indices `state_indices[b]`. This is what
+// lets us keep `state_scores` on the GPU across `compute_level` calls,
+// rather than re-uploading the host buffer (which has the same values)
+// every level.
+//
+// One thread per batch element, flat 1D launch. Trivial.
+extern "C" __global__ void scatter_results(
+    const unsigned int *state_indices,  // [B]
+    const float *result,                 // [B]
+    float *state_scores,                 // [NUM_STATES]
+    int batch_size
+) {
+    int b = blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= batch_size) return;
+    state_scores[state_indices[b]] = result[b];
+}
 "#;
 
 const NUM_DICE_F: usize = 252;
@@ -286,9 +304,49 @@ const REDUCE_BLOCK_DIM: u32 = 64;
 /// combos in one block per state, with 4 idle threads at the tail.
 const ENTRY_BLOCK_DIM: u32 = 256;
 
+/// Mutable, lazily-allocated device-side buffers that persist across
+/// `compute_level` calls.
+///
+/// `state_scores` is allocated once at backend construction (NUM_STATES f32s
+/// = 4 MiB), zero-initialized, and updated in place by the `scatter_results`
+/// kernel after each level so the next level's `build_third_dice` can read
+/// it directly from device memory — no per-level H→D upload of the host
+/// state_scores buffer needed.
+///
+/// The five intermediate buffers (`third_dice`, `second_keepers`,
+/// `second_dice`, `first_keepers`, `first_dice`) and the per-state `result`
+/// scale with batch size and are lazily grown to the largest batch we've
+/// seen (with a small headroom). We never shrink — once allocated, the
+/// buffers live until the backend drops.
+struct DeviceState {
+    /// 4 MiB = NUM_STATES × f32. Persistent across all `compute_level`
+    /// calls (and across multiple `Scores::new_with` builds — see comment
+    /// in `compute_level_inner` about why that's safe given deterministic
+    /// per-state EVs).
+    state_scores: CudaSlice<f32>,
+
+    // Per-call intermediates, sized to `capacity_batch`. None until the
+    // first `compute_level` call grows them.
+    third_dice: Option<CudaSlice<f32>>,
+    second_keepers: Option<CudaSlice<f32>>,
+    second_dice: Option<CudaSlice<f32>>,
+    first_keepers: Option<CudaSlice<f32>>,
+    first_dice: Option<CudaSlice<f32>>,
+    result: Option<CudaSlice<f32>>,
+    /// Number of states the buffers above can currently hold. 0 means
+    /// uninitialized.
+    capacity_batch: usize,
+
+    /// Per-call upload of state indices: lazily grown like the
+    /// intermediates. The host-side state_indices Vec<u32> is rebuilt per
+    /// call; only the device buffer reuses memory.
+    state_indices: Option<CudaSlice<u32>>,
+}
+
 /// GPU-resident [`BuildBackend`]. Construct once with [`CudaBuildBackend::new`]
-/// and reuse across multiple `Scores::new_with` calls (each call makes its own
-/// per-level uploads but reuses the static tables already on device).
+/// and reuse across multiple `Scores::new_with` calls (each call makes its
+/// own per-level scatter; the static tables, kernels, cuBLAS handle, and
+/// device buffers are all reused).
 pub struct CudaBuildBackend {
     /// CUDA context — keeps the device alive and the loaded module / cuBLAS
     /// handle valid. Held as an `Arc` so the stream and module references
@@ -307,6 +365,7 @@ pub struct CudaBuildBackend {
     f_build_third_dice: CudaFunction,
     f_masked_max: CudaFunction,
     f_initial_roll_ev: CudaFunction,
+    f_scatter_results: CudaFunction,
 
     // Device-resident static tables, uploaded once.
     /// 462 × 252 row-major. cuBLAS reads it as a 252×462 column-major view of
@@ -323,12 +382,18 @@ pub struct CudaBuildBackend {
     /// EntryAction index (`EntryAction::ONE.as_idx() == 0`, …,
     /// `EntryAction::SIX.as_idx() == 5`).
     yahtzee_dice: CudaSlice<i8>,
+
+    /// Lazily-grown per-call device buffers. Mutex (rather than
+    /// `RefCell`) so `BuildBackend: Sync` holds; in practice
+    /// `Scores::new_with` calls `compute_level` serially.
+    device_state: Mutex<DeviceState>,
 }
 
 impl CudaBuildBackend {
     /// Initialize the CUDA backend on device 0: load the driver, allocate a
-    /// stream, compile and load the custom kernels, and upload the static
-    /// tables.
+    /// stream, compile and load the custom kernels, upload the static
+    /// tables, and zero-allocate the persistent device-side state_scores
+    /// buffer.
     pub fn new() -> Result<Self, CudaError> {
         let ctx = CudaContext::new(0)?;
         let stream = ctx.default_stream();
@@ -341,6 +406,7 @@ impl CudaBuildBackend {
         let f_build_third_dice = module.load_function("build_third_dice")?;
         let f_masked_max = module.load_function("masked_max")?;
         let f_initial_roll_ev = module.load_function("initial_roll_ev")?;
+        let f_scatter_results = module.load_function("scatter_results")?;
 
         // Upload static tables.
         let kt = crate::KEEPERS_TO_DICE_PROBABILITIES
@@ -367,6 +433,10 @@ impl CudaBuildBackend {
         let dice_to_keepers = stream.clone_htod(dk)?;
         let dice_and_entry_scores = stream.clone_htod(&des)?;
         let yahtzee_dice = stream.clone_htod(&yd)?;
+
+        // Persistent state_scores: NUM_STATES f32 = 4 MiB, zero-initialized.
+        // Lives until the backend drops.
+        let state_scores = stream.alloc_zeros::<f32>(NUM_STATES as usize)?;
         stream.synchronize()?;
 
         Ok(Self {
@@ -376,45 +446,107 @@ impl CudaBuildBackend {
             f_build_third_dice,
             f_masked_max,
             f_initial_roll_ev,
+            f_scatter_results,
             keepers_to_dice,
             dice_to_keepers,
             dice_and_entry_scores,
             yahtzee_dice,
+            device_state: Mutex::new(DeviceState {
+                state_scores,
+                third_dice: None,
+                second_keepers: None,
+                second_dice: None,
+                first_keepers: None,
+                first_dice: None,
+                result: None,
+                capacity_batch: 0,
+                state_indices: None,
+            }),
         })
     }
 
+    /// Ensure the per-call device buffers can hold at least `batch` states.
+    /// Grows by reallocating to `batch` exactly the first time we hit a new
+    /// max; subsequent calls with smaller batches reuse the existing
+    /// allocation. We never shrink.
+    fn ensure_capacity(
+        &self,
+        batch: usize,
+        ds: &mut DeviceState,
+    ) -> Result<(), CudaError> {
+        if batch <= ds.capacity_batch {
+            return Ok(());
+        }
+        let stream = &self.stream;
+        ds.third_dice = Some(stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?);
+        ds.second_keepers = Some(stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?);
+        ds.second_dice = Some(stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?);
+        ds.first_keepers = Some(stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?);
+        ds.first_dice = Some(stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?);
+        ds.result = Some(stream.alloc_zeros::<f32>(batch)?);
+        ds.state_indices = Some(stream.alloc_zeros::<u32>(batch)?);
+        ds.capacity_batch = batch;
+        Ok(())
+    }
+
     /// The kernel-and-cuBLAS pipeline for a single level. Returns the EV per
-    /// state in `states`. `state_scores` must be the up-to-date DP buffer
-    /// after all higher levels have been computed.
+    /// state in `states`. `_state_scores` is unused — the device-resident
+    /// `device_state.state_scores` is kept in sync via the `scatter_results`
+    /// kernel, so we don't re-upload the host buffer every level.
+    ///
+    /// Note on multi-build reuse: the device-side `state_scores` carries
+    /// values from prior `Scores::new_with` calls. That's safe because the
+    /// per-state EV is deterministic — any state's child indices read at
+    /// the level the kernel cares about hold the same values either way.
+    /// Indices BELOW the current level may hold stale (final-EV) values,
+    /// but the kernel never reads them: `build_third_dice` only reads
+    /// state_scores at child indices, which are at strictly higher levels.
     fn compute_level_inner(
         &self,
         states: &[State],
-        state_scores: &[f32],
+        _state_scores: &[f32],
     ) -> Result<Vec<f32>, CudaError> {
         let stream = &self.stream;
         let batch = states.len();
         let batch_i32 = batch as i32;
 
-        // ------- H→D uploads ----------------------------------------------
-        // State indices: pack each State to its u32 index (matches the
-        // `From<State> for usize` encoding in lib.rs). The kernel unpacks.
-        let state_indices_h: Vec<u32> = states
-            .iter()
-            .map(|s| usize::from(*s) as u32)
-            .collect();
-        let state_indices_d = stream.clone_htod(&state_indices_h)?;
+        let mut ds = self
+            .device_state
+            .lock()
+            .expect("CudaBuildBackend mutex poisoned");
 
-        debug_assert_eq!(state_scores.len(), NUM_STATES as usize);
-        let state_scores_d = stream.clone_htod(state_scores)?;
+        // Lazy-grow the per-call buffers if this batch is the largest yet.
+        self.ensure_capacity(batch, &mut ds)?;
 
-        // ------- Device buffers for intermediates -------------------------
-        let mut third_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
-        let mut second_keepers: CudaSlice<f32> =
-            stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?;
-        let mut second_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
-        let mut first_keepers: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?;
-        let mut first_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
-        let mut result: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch)?;
+        // Split-borrow the persistent buffers into disjoint mutable
+        // references. Without this we can't both read one buffer and write
+        // another in the same statement (the borrow checker treats methods
+        // on the same `MutexGuard` as overlapping borrows).
+        let DeviceState {
+            ref mut state_scores,
+            ref mut third_dice,
+            ref mut second_keepers,
+            ref mut second_dice,
+            ref mut first_keepers,
+            ref mut first_dice,
+            ref mut result,
+            ref mut state_indices,
+            ..
+        } = *ds;
+        let third_dice = third_dice.as_mut().expect("ensured");
+        let second_keepers = second_keepers.as_mut().expect("ensured");
+        let second_dice = second_dice.as_mut().expect("ensured");
+        let first_keepers = first_keepers.as_mut().expect("ensured");
+        let first_dice = first_dice.as_mut().expect("ensured");
+        let result = result.as_mut().expect("ensured");
+        let state_indices = state_indices.as_mut().expect("ensured");
+
+        // ------- H→D upload of state indices ------------------------------
+        // Pack each State to its u32 index (matches `From<State> for usize`
+        // in lib.rs). The kernel unpacks. Reuses the persistent device
+        // buffer; only the first `batch` elements are written.
+        let state_indices_h: Vec<u32> = states.iter().map(|s| usize::from(*s) as u32).collect();
+        stream.memcpy_htod(&state_indices_h, state_indices)?;
 
         // ------- Step 1: build_third_dice ---------------------------------
         // Grid: (batch, 1, 1) blocks of (256, 1, 1) threads. batch on x to
@@ -428,11 +560,11 @@ impl CudaBuildBackend {
         unsafe {
             stream
                 .launch_builder(&self.f_build_third_dice)
-                .arg(&state_indices_d)
-                .arg(&state_scores_d)
+                .arg(&*state_indices)
+                .arg(&*state_scores)
                 .arg(&self.dice_and_entry_scores)
                 .arg(&self.yahtzee_dice)
-                .arg(&mut third_dice)
+                .arg(&mut *third_dice)
                 .arg(&batch_i32)
                 .launch(cfg_entry)?;
         }
@@ -471,8 +603,8 @@ impl CudaBuildBackend {
             self.blas.gemm(
                 gemm_cfg,
                 &self.keepers_to_dice,
-                &third_dice,
-                &mut second_keepers,
+                &*third_dice,
+                &mut *second_keepers,
             )?;
         }
 
@@ -487,9 +619,9 @@ impl CudaBuildBackend {
         unsafe {
             stream
                 .launch_builder(&self.f_masked_max)
-                .arg(&second_keepers)
+                .arg(&*second_keepers)
                 .arg(&self.dice_to_keepers)
-                .arg(&mut second_dice)
+                .arg(&mut *second_dice)
                 .arg(&batch_i32)
                 .launch(cfg_reduce)?;
         }
@@ -499,8 +631,8 @@ impl CudaBuildBackend {
             self.blas.gemm(
                 gemm_cfg,
                 &self.keepers_to_dice,
-                &second_dice,
-                &mut first_keepers,
+                &*second_dice,
+                &mut *first_keepers,
             )?;
         }
 
@@ -508,9 +640,9 @@ impl CudaBuildBackend {
         unsafe {
             stream
                 .launch_builder(&self.f_masked_max)
-                .arg(&first_keepers)
+                .arg(&*first_keepers)
                 .arg(&self.dice_to_keepers)
-                .arg(&mut first_dice)
+                .arg(&mut *first_dice)
                 .arg(&batch_i32)
                 .launch(cfg_reduce)?;
         }
@@ -527,15 +659,44 @@ impl CudaBuildBackend {
         unsafe {
             stream
                 .launch_builder(&self.f_initial_roll_ev)
-                .arg(&first_dice)
+                .arg(&*first_dice)
                 .arg(&self.keepers_to_dice)
-                .arg(&mut result)
+                .arg(&mut *result)
                 .arg(&batch_i32)
                 .launch(cfg_marg)?;
         }
 
-        // ------- D→H result -----------------------------------------------
-        let host_result = stream.clone_dtoh(&result)?;
+        // ------- Step 7: scatter result into device state_scores ----------
+        // After this, the next level's `build_third_dice` can read its
+        // children's EVs directly from device memory; no host round trip.
+        const SCATTER_BLOCK: u32 = 256;
+        let scatter_blocks = ((batch as u32) + SCATTER_BLOCK - 1) / SCATTER_BLOCK;
+        let cfg_scatter = LaunchConfig {
+            grid_dim: (scatter_blocks, 1, 1),
+            block_dim: (SCATTER_BLOCK, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        unsafe {
+            stream
+                .launch_builder(&self.f_scatter_results)
+                .arg(&*state_indices)
+                .arg(&*result)
+                .arg(&mut *state_scores)
+                .arg(&batch_i32)
+                .launch(cfg_scatter)?;
+        }
+
+        // ------- D→H of just the per-state result -------------------------
+        // The trait still wants Vec<f32>; the host-side `Scores::set_scores`
+        // also writes these into its own state_scores Array1. (That host-
+        // side write is now redundant work for the CUDA path, but keeping
+        // the trait shape lets `Scores` remain backend-agnostic and the
+        // CPU path keep its straight-line read of `state_scores: &[f32]`.)
+        //
+        // The persistent `result` buffer may be larger than `batch`; copy
+        // only the first `batch` floats out.
+        let mut host_result = vec![0.0_f32; batch];
+        stream.memcpy_dtoh(&result.slice(0..batch), &mut host_result)?;
         stream.synchronize()?;
         Ok(host_result)
     }

--- a/crates/core/src/linalg/cuda.rs
+++ b/crates/core/src/linalg/cuda.rs
@@ -37,46 +37,48 @@ use cudarc::nvrtc::compile_ptx;
 
 use crate::{BuildBackend, State, NUM_STATES};
 
-/// Errors that can prevent the CUDA backend from initializing or running.
+/// Errors raised by the CUDA backend during construction (`new`) or per-level
+/// compute (`compute_level`).
 #[derive(Debug)]
-pub enum CudaInitError {
-    /// Failed to load libcuda.so / libnvrtc.so / libcublas.so, or the GPU
-    /// is unreachable. The string is the cudarc driver-API error message.
+pub enum CudaError {
+    /// Failed to load libcuda.so / libnvrtc.so / libcublas.so, the GPU is
+    /// unreachable, an allocation failed, a kernel launch returned a CUDA
+    /// error, etc. The string is the cudarc driver-API error message.
     Driver(String),
     /// NVRTC failed to compile a kernel. Almost always a code bug in this
     /// crate's kernel sources rather than something the user can fix.
     Compile(String),
-    /// cuBLAS initialization failed.
+    /// cuBLAS initialization or sgemm call failed.
     Cublas(String),
 }
 
-impl std::fmt::Display for CudaInitError {
+impl std::fmt::Display for CudaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CudaInitError::Driver(msg) => write!(f, "CUDA driver error: {msg}"),
-            CudaInitError::Compile(msg) => write!(f, "NVRTC compile error: {msg}"),
-            CudaInitError::Cublas(msg) => write!(f, "cuBLAS error: {msg}"),
+            CudaError::Driver(msg) => write!(f, "CUDA driver error: {msg}"),
+            CudaError::Compile(msg) => write!(f, "NVRTC compile error: {msg}"),
+            CudaError::Cublas(msg) => write!(f, "cuBLAS error: {msg}"),
         }
     }
 }
 
-impl std::error::Error for CudaInitError {}
+impl std::error::Error for CudaError {}
 
-impl From<cudarc::driver::DriverError> for CudaInitError {
+impl From<cudarc::driver::DriverError> for CudaError {
     fn from(err: cudarc::driver::DriverError) -> Self {
-        CudaInitError::Driver(format!("{err:?}"))
+        CudaError::Driver(format!("{err:?}"))
     }
 }
 
-impl From<cudarc::nvrtc::CompileError> for CudaInitError {
+impl From<cudarc::nvrtc::CompileError> for CudaError {
     fn from(err: cudarc::nvrtc::CompileError) -> Self {
-        CudaInitError::Compile(format!("{err:?}"))
+        CudaError::Compile(format!("{err:?}"))
     }
 }
 
-impl From<cudarc::cublas::result::CublasError> for CudaInitError {
+impl From<cudarc::cublas::result::CublasError> for CudaError {
     fn from(err: cudarc::cublas::result::CublasError) -> Self {
-        CudaInitError::Cublas(format!("{err:?}"))
+        CudaError::Cublas(format!("{err:?}"))
     }
 }
 
@@ -327,7 +329,7 @@ impl CudaBuildBackend {
     /// Initialize the CUDA backend on device 0: load the driver, allocate a
     /// stream, compile and load the custom kernels, and upload the static
     /// tables.
-    pub fn new() -> Result<Self, CudaInitError> {
+    pub fn new() -> Result<Self, CudaError> {
         let ctx = CudaContext::new(0)?;
         let stream = ctx.default_stream();
         let blas = CudaBlas::new(stream.clone())?;
@@ -388,7 +390,7 @@ impl CudaBuildBackend {
         &self,
         states: &[State],
         state_scores: &[f32],
-    ) -> Result<Vec<f32>, CudaInitError> {
+    ) -> Result<Vec<f32>, CudaError> {
         let stream = &self.stream;
         let batch = states.len();
         let batch_i32 = batch as i32;
@@ -540,16 +542,19 @@ impl CudaBuildBackend {
 }
 
 impl BuildBackend for CudaBuildBackend {
-    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32> {
+    type Error = CudaError;
+
+    fn compute_level(
+        &self,
+        states: &[State],
+        state_scores: &[f32],
+    ) -> Result<Vec<f32>, Self::Error> {
         if states.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        // BuildBackend is infallible from the caller's perspective; CUDA
-        // failure mid-build is fatal (the DP table would be wrong) so we
-        // panic with the underlying error rather than silently returning
-        // bad data. There's no recovery path: the host-side `Scores::new_with`
-        // doesn't have a way to retry on a different backend.
+        // Errors propagate to `Scores::new_with`'s caller; mid-build CUDA
+        // failure leaves the partial DP buffer in an inconsistent state but
+        // the `Scores` value is dropped so it's never observed.
         self.compute_level_inner(states, state_scores)
-            .expect("CUDA compute_level failed")
     }
 }

--- a/crates/core/src/linalg/cuda.rs
+++ b/crates/core/src/linalg/cuda.rs
@@ -1,0 +1,555 @@
+//! CUDA implementation of [`crate::BuildBackend`].
+//!
+//! The level-batched DP fill mapped to the GPU. Per [`crate::BuildBackend`]'s
+//! contract, `compute_level` receives a batch of states all at the same DP
+//! level plus the read-only `state_scores` buffer, and returns one EV per
+//! state. We exploit the batch in two ways:
+//!
+//! 1. The two GEMVs in the per-state pipeline (`keepers_from_dice`, 252→462)
+//!    become one batched GEMM each: `(B × 252) · (252 × 462)`. cuBLAS does
+//!    them as a single launch per batch.
+//! 2. The masked-max reduction in `dice_from_keepers` (462→252, gated by the
+//!    252×462 mask) becomes a single custom kernel over the whole batch: one
+//!    block per `(dice_idx, state_b)`, 64-wide reduction across keepers.
+//!
+//! The branchy "build entry-actions matrix and fold-axis to roll-3 dice" step
+//! is also a custom kernel — per state it walks 13 entries, branches on
+//! validity / joker rule / upper bonus, and gathers child-state EVs from
+//! device-resident `state_scores`.
+//!
+//! All static tables (`KEEPERS_TO_DICE_PROBABILITIES`, `DICE_TO_ALLOWED_KEEPERS`,
+//! `DICE_AND_ENTRY_SCORES`, `YAHTZEE_DICE`) are uploaded once at backend
+//! construction time. `state_scores` is uploaded per `compute_level` call
+//! (one ~4 MiB H→D copy per level — small relative to the kernel work and
+//! easy to reason about).
+//!
+//! cudarc loads libcuda / libcublas / libnvrtc dynamically (the
+//! `fallback-dynamic-loading` feature). No CUDA headers or `nvcc` are
+//! required at build time, only the runtime `.so`s at run time.
+
+use std::sync::Arc;
+
+use cudarc::cublas::{sys::cublasOperation_t, CudaBlas, Gemm, GemmConfig};
+use cudarc::driver::{
+    CudaContext, CudaFunction, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
+};
+use cudarc::nvrtc::compile_ptx;
+
+use crate::{BuildBackend, State, NUM_STATES};
+
+/// Errors that can prevent the CUDA backend from initializing or running.
+#[derive(Debug)]
+pub enum CudaInitError {
+    /// Failed to load libcuda.so / libnvrtc.so / libcublas.so, or the GPU
+    /// is unreachable. The string is the cudarc driver-API error message.
+    Driver(String),
+    /// NVRTC failed to compile a kernel. Almost always a code bug in this
+    /// crate's kernel sources rather than something the user can fix.
+    Compile(String),
+    /// cuBLAS initialization failed.
+    Cublas(String),
+}
+
+impl std::fmt::Display for CudaInitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CudaInitError::Driver(msg) => write!(f, "CUDA driver error: {msg}"),
+            CudaInitError::Compile(msg) => write!(f, "NVRTC compile error: {msg}"),
+            CudaInitError::Cublas(msg) => write!(f, "cuBLAS error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CudaInitError {}
+
+impl From<cudarc::driver::DriverError> for CudaInitError {
+    fn from(err: cudarc::driver::DriverError) -> Self {
+        CudaInitError::Driver(format!("{err:?}"))
+    }
+}
+
+impl From<cudarc::nvrtc::CompileError> for CudaInitError {
+    fn from(err: cudarc::nvrtc::CompileError) -> Self {
+        CudaInitError::Compile(format!("{err:?}"))
+    }
+}
+
+impl From<cudarc::cublas::result::CublasError> for CudaInitError {
+    fn from(err: cudarc::cublas::result::CublasError) -> Self {
+        CudaInitError::Cublas(format!("{err:?}"))
+    }
+}
+
+/// Source of the three custom kernels — compiled once at construction via
+/// NVRTC. See module docs for the math each one implements; the kernels
+/// themselves are intentionally written to map 1:1 onto the per-state CPU
+/// pipeline so a per-state diff against `state_value_with(NdarrayBackend)`
+/// is a useful debug step.
+const KERNEL_SRC: &str = r#"
+// Build the (B, 252) `third_dice` array: per state in the batch, fold the
+// 13-entry × 252-dice "entry_actions" matrix on its action axis. Each entry
+// in that matrix is `score + state_scores[child]` for valid `(action, dice)`
+// pairs (joker-aware, upper-bonus-aware, yahtzee-bonus-aware), 0 for invalid.
+// We don't materialize the (13 × 252) matrix; we fold it on the fly.
+//
+// Grid shape: gridDim = (batch, 1, 1), blockDim = (256, 1, 1). batch goes on
+// gridDim.x (limit 2^31) since gridDim.y is capped at 65535 and the build's
+// largest level can exceed that. dice_idx maps to threadIdx.x; threads with
+// threadIdx.x >= 252 early-out.
+extern "C" __global__ void build_third_dice(
+    const unsigned int *state_indices,           // [B]
+    const float *state_scores,                   // [NUM_STATES] (1<<20 = 1M)
+    const unsigned char *dice_and_entry_scores,  // [13 * 252]
+    const signed char *yahtzee_dice,             // [252]; -1 for non-Yahtzee, 0..5 for upper
+    float *third_dice,                           // out [B * 252]
+    int batch_size
+) {
+    int dice_idx = threadIdx.x;
+    int state_b  = blockIdx.x;
+    if (dice_idx >= 252 || state_b >= batch_size) return;
+
+    unsigned int sidx = state_indices[state_b];
+    // Same packing as `impl From<State> for usize` in lib.rs:
+    //   bits 0..5 = upper_score_remaining (0..=63)
+    //   bit 6     = yahtzee_bonus_eligible
+    //   bits 7..19 = entries (13-bit EntryAction bitset)
+    unsigned int entries_bits = (sidx >> 7) & 0x1FFFu;
+    unsigned int eligible     = (sidx >> 6) & 1u;
+    unsigned int upper_rem    = sidx & 0x3Fu;
+
+    int yd = (int) yahtzee_dice[dice_idx];   // -1 or 0..5
+    int is_yahtzee = (yd >= 0);
+
+    // Joker rule preconditions: YAHTZEE box (bit 11) is filled, the dice
+    // is a Yahtzee, and the matching upper category (bit yd) is also filled.
+    int yahtzee_filled = (entries_bits >> 11) & 1;
+    int joker_active = is_yahtzee && yahtzee_filled
+        && (yd >= 0 ? ((entries_bits >> yd) & 1) : 0);
+
+    // Yahtzee +100 bonus depends only on (dice, eligibility), not on action,
+    // so it's a turn-level constant we can hoist out of the action loop.
+    float yahtzee_bonus = (is_yahtzee && eligible) ? 100.0f : 0.0f;
+
+    float best = 0.0f;
+
+    #pragma unroll
+    for (int action_idx = 0; action_idx < 13; action_idx++) {
+        // is_valid_action: !entries.contains(action)
+        if ((entries_bits >> action_idx) & 1) continue;
+
+        unsigned int action_bit = 1u << action_idx;
+        unsigned char raw_score = dice_and_entry_scores[action_idx * 252 + dice_idx];
+        unsigned int normal_score;
+
+        // Joker rule for lower-section fixed scores (matches
+        // `joker_lower_score` in lib.rs):
+        //   FULL_HOUSE (8)     -> 25
+        //   SMALL_STRAIGHT (9) -> 30
+        //   LARGE_STRAIGHT (10)-> 40
+        if (joker_active) {
+            switch (action_idx) {
+                case 8:  normal_score = 25; break;
+                case 9:  normal_score = 30; break;
+                case 10: normal_score = 40; break;
+                default: normal_score = (unsigned int) raw_score;
+            }
+        } else {
+            normal_score = (unsigned int) raw_score;
+        }
+
+        // Compute child state. Mirror `State::child` exactly:
+        //   entries |= action_bit
+        //   if upper category: upper_rem = saturating_sub(upper_rem, raw_score)
+        //   if YAHTZEE && is_yahtzee: eligible = 1
+        unsigned int child_entries = entries_bits | action_bit;
+        unsigned int child_upper = upper_rem;
+        if (action_idx < 6) {
+            unsigned int s = (unsigned int) raw_score;
+            child_upper = (child_upper > s) ? (child_upper - s) : 0;
+        }
+        unsigned int child_eligible = eligible;
+        if (action_idx == 11 && is_yahtzee) {
+            child_eligible = 1;
+        }
+
+        unsigned int child_idx = (child_entries << 7) | (child_eligible << 6) | child_upper;
+
+        // Upper bonus fires when this entry completes the upper section.
+        float upper_bonus = ((upper_rem != 0) && (child_upper == 0)) ? 35.0f : 0.0f;
+
+        float total = (float) normal_score + upper_bonus + yahtzee_bonus
+                    + state_scores[child_idx];
+
+        if (total > best) best = total;
+    }
+
+    third_dice[state_b * 252 + dice_idx] = best;
+}
+
+// Masked max-reduction: for each (state_b, dice_idx), output the max over
+// keepers k of `mask[dice_idx, k] * keeper_values[state_b, k]`. The mask is
+// 0 / 1, so this is "max over keepers allowed for this dice combo." The
+// masked product (rather than a branch) matches the CPU implementation
+// exactly and stays branchless inside the inner loop.
+//
+// Grid shape: gridDim = (batch, 252, 1), blockDim = (64, 1, 1). batch is on
+// gridDim.x (no limit); dice_idx is on gridDim.y (252 < 65535). 64 threads
+// cooperate on the 462-wide reduction (~7 keepers per thread). Shared memory
+// holds the per-thread max.
+extern "C" __global__ void masked_max(
+    const float *keeper_values,  // [B * 462]
+    const float *mask,           // [252 * 462] (DICE_TO_ALLOWED_KEEPERS, dice-major)
+    float *out,                  // [B * 252]
+    int batch_size
+) {
+    int state_b  = blockIdx.x;
+    int dice_idx = blockIdx.y;
+    int tid      = threadIdx.x;
+    if (state_b >= batch_size) return;
+
+    extern __shared__ float sdata[];
+
+    float my_max = 0.0f;
+    const float *kv = keeper_values + state_b * 462;
+    const float *mr = mask + dice_idx * 462;
+
+    for (int k = tid; k < 462; k += blockDim.x) {
+        float v = kv[k] * mr[k];
+        if (v > my_max) my_max = v;
+    }
+
+    sdata[tid] = my_max;
+    __syncthreads();
+
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            float other = sdata[tid + s];
+            if (other > sdata[tid]) sdata[tid] = other;
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        out[state_b * 252 + dice_idx] = sdata[0];
+    }
+}
+
+// Final marginal: for each state_b, compute sum_d first_dice[b, d] * row0[d],
+// where row0 is row 0 of KEEPERS_TO_DICE_PROBABILITIES (the initial-roll
+// distribution over the 252 five-dice combos). One block per state, 64
+// threads cooperate on the 252-wide sum.
+extern "C" __global__ void initial_roll_ev(
+    const float *first_dice,   // [B * 252]
+    const float *row0,         // [252]
+    float *out,                // [B]
+    int batch_size
+) {
+    int state_b = blockIdx.x;
+    int tid     = threadIdx.x;
+    if (state_b >= batch_size) return;
+
+    extern __shared__ float sdata[];
+
+    float my_sum = 0.0f;
+    const float *fd = first_dice + state_b * 252;
+
+    for (int d = tid; d < 252; d += blockDim.x) {
+        my_sum += fd[d] * row0[d];
+    }
+
+    sdata[tid] = my_sum;
+    __syncthreads();
+
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            sdata[tid] += sdata[tid + s];
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        out[state_b] = sdata[0];
+    }
+}
+"#;
+
+const NUM_DICE_F: usize = 252;
+const NUM_KEEPERS_F: usize = 462;
+const NUM_ENTRIES_F: usize = 13;
+/// Threads per block for the masked-max and final-marginal kernels. Picked
+/// for divisibility (462 / 64 = 8 inner iters with one tail; 252 / 64 = 4
+/// inner iters with one tail) and to keep shared-mem reductions short.
+const REDUCE_BLOCK_DIM: u32 = 64;
+/// Threads per block for the entry-actions kernel. 256 covers all 252 dice
+/// combos in one block per state, with 4 idle threads at the tail.
+const ENTRY_BLOCK_DIM: u32 = 256;
+
+/// GPU-resident [`BuildBackend`]. Construct once with [`CudaBuildBackend::new`]
+/// and reuse across multiple `Scores::new_with` calls (each call makes its own
+/// per-level uploads but reuses the static tables already on device).
+pub struct CudaBuildBackend {
+    /// CUDA context — keeps the device alive and the loaded module / cuBLAS
+    /// handle valid. Held as an `Arc` so the stream and module references
+    /// stay valid for the backend's lifetime.
+    #[allow(dead_code)]
+    ctx: Arc<CudaContext>,
+    /// Default stream for all H→D copies, kernel launches, and D→H copies.
+    /// Everything is serialized on this stream — concurrent streams aren't
+    /// useful here because every level depends on the previous one.
+    stream: Arc<CudaStream>,
+    /// cuBLAS handle, bound to `stream`. Used for the two batched GEMMs that
+    /// implement `keepers_from_dice` (252→462) per level.
+    blas: CudaBlas,
+
+    // Compiled kernel handles. Loaded once at construction.
+    f_build_third_dice: CudaFunction,
+    f_masked_max: CudaFunction,
+    f_initial_roll_ev: CudaFunction,
+
+    // Device-resident static tables, uploaded once.
+    /// 462 × 252 row-major. cuBLAS reads it as a 252×462 column-major view of
+    /// the transpose; that matches what we want (see `compute_level` for the
+    /// transpose-juggling explanation).
+    keepers_to_dice: CudaSlice<f32>,
+    /// 252 × 462 row-major mask, indexed by `(dice_idx, keeper_idx)`. The
+    /// `masked_max` kernel reads one row per `(dice_idx, state_b)` block.
+    dice_to_keepers: CudaSlice<f32>,
+    /// 13 × 252 row-major raw entry scores (no joker rule applied — the
+    /// kernel layers it on at lookup time).
+    dice_and_entry_scores: CudaSlice<u8>,
+    /// 252 entries: -1 for non-Yahtzee dice, 0..5 = matching upper
+    /// EntryAction index (`EntryAction::ONE.as_idx() == 0`, …,
+    /// `EntryAction::SIX.as_idx() == 5`).
+    yahtzee_dice: CudaSlice<i8>,
+}
+
+impl CudaBuildBackend {
+    /// Initialize the CUDA backend on device 0: load the driver, allocate a
+    /// stream, compile and load the custom kernels, and upload the static
+    /// tables.
+    pub fn new() -> Result<Self, CudaInitError> {
+        let ctx = CudaContext::new(0)?;
+        let stream = ctx.default_stream();
+        let blas = CudaBlas::new(stream.clone())?;
+
+        // Compile and load kernels via NVRTC. ~50ms first time; PTX is cached
+        // by the driver so re-running the same binary is faster.
+        let ptx = compile_ptx(KERNEL_SRC)?;
+        let module = ctx.load_module(ptx)?;
+        let f_build_third_dice = module.load_function("build_third_dice")?;
+        let f_masked_max = module.load_function("masked_max")?;
+        let f_initial_roll_ev = module.load_function("initial_roll_ev")?;
+
+        // Upload static tables.
+        let kt = crate::KEEPERS_TO_DICE_PROBABILITIES
+            .as_slice()
+            .expect("KEEPERS_TO_DICE_PROBABILITIES is contiguous");
+        let dk = crate::DICE_TO_ALLOWED_KEEPERS
+            .as_slice()
+            .expect("DICE_TO_ALLOWED_KEEPERS is contiguous");
+        let des: Vec<u8> = crate::DICE_AND_ENTRY_SCORES.iter().copied().collect();
+        let yd: Vec<i8> = crate::YAHTZEE_DICE
+            .iter()
+            .map(|opt| match opt {
+                None => -1_i8,
+                Some(action) => action.as_idx() as i8,
+            })
+            .collect();
+
+        debug_assert_eq!(kt.len(), NUM_KEEPERS_F * NUM_DICE_F);
+        debug_assert_eq!(dk.len(), NUM_DICE_F * NUM_KEEPERS_F);
+        debug_assert_eq!(des.len(), NUM_ENTRIES_F * NUM_DICE_F);
+        debug_assert_eq!(yd.len(), NUM_DICE_F);
+
+        let keepers_to_dice = stream.clone_htod(kt)?;
+        let dice_to_keepers = stream.clone_htod(dk)?;
+        let dice_and_entry_scores = stream.clone_htod(&des)?;
+        let yahtzee_dice = stream.clone_htod(&yd)?;
+        stream.synchronize()?;
+
+        Ok(Self {
+            ctx,
+            stream,
+            blas,
+            f_build_third_dice,
+            f_masked_max,
+            f_initial_roll_ev,
+            keepers_to_dice,
+            dice_to_keepers,
+            dice_and_entry_scores,
+            yahtzee_dice,
+        })
+    }
+
+    /// The kernel-and-cuBLAS pipeline for a single level. Returns the EV per
+    /// state in `states`. `state_scores` must be the up-to-date DP buffer
+    /// after all higher levels have been computed.
+    fn compute_level_inner(
+        &self,
+        states: &[State],
+        state_scores: &[f32],
+    ) -> Result<Vec<f32>, CudaInitError> {
+        let stream = &self.stream;
+        let batch = states.len();
+        let batch_i32 = batch as i32;
+
+        // ------- H→D uploads ----------------------------------------------
+        // State indices: pack each State to its u32 index (matches the
+        // `From<State> for usize` encoding in lib.rs). The kernel unpacks.
+        let state_indices_h: Vec<u32> = states
+            .iter()
+            .map(|s| usize::from(*s) as u32)
+            .collect();
+        let state_indices_d = stream.clone_htod(&state_indices_h)?;
+
+        debug_assert_eq!(state_scores.len(), NUM_STATES as usize);
+        let state_scores_d = stream.clone_htod(state_scores)?;
+
+        // ------- Device buffers for intermediates -------------------------
+        let mut third_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
+        let mut second_keepers: CudaSlice<f32> =
+            stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?;
+        let mut second_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
+        let mut first_keepers: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_KEEPERS_F)?;
+        let mut first_dice: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch * NUM_DICE_F)?;
+        let mut result: CudaSlice<f32> = stream.alloc_zeros::<f32>(batch)?;
+
+        // ------- Step 1: build_third_dice ---------------------------------
+        // Grid: (batch, 1, 1) blocks of (256, 1, 1) threads. batch on x to
+        // dodge the gridDim.y 65535 cap. ENTRY_BLOCK_DIM=256 covers all 252
+        // dice in one block; tail threads (252..255) early-out.
+        let cfg_entry = LaunchConfig {
+            grid_dim: (batch as u32, 1, 1),
+            block_dim: (ENTRY_BLOCK_DIM, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        unsafe {
+            stream
+                .launch_builder(&self.f_build_third_dice)
+                .arg(&state_indices_d)
+                .arg(&state_scores_d)
+                .arg(&self.dice_and_entry_scores)
+                .arg(&self.yahtzee_dice)
+                .arg(&mut third_dice)
+                .arg(&batch_i32)
+                .launch(cfg_entry)?;
+        }
+
+        // ------- Step 2: keepers_from_dice via cuBLAS sgemm ---------------
+        // Logical: second_keepers[b,k] = Σ_d KEEPERS_TO_DICE_PROBABILITIES[k,d] * third_dice[b,d]
+        //
+        // Memory layout (row-major):
+        //   keepers_to_dice (M):  shape (462, 252)
+        //   third_dice (X):       shape (B, 252)
+        //   second_keepers (Y):   shape (B, 462)
+        //
+        // cuBLAS is column-major. Trick: row-major data of logical shape
+        // (rows, cols) read as cm with shape (cols, rows) gives the
+        // transpose. To produce Y_rm (B×462) we compute Y^T_cm (462×B),
+        // since Y_rm and Y^T_cm share storage. Y^T = M · X^T, so call
+        // sgemm with op_a=T (read M_rm as cm gives M^T → transpose back to
+        // M), op_b=N (read X_rm as cm already gives X^T, no transpose).
+        //   m = K = 462, n = B, k = D = 252
+        //   lda = D = 252 (cm rows of M_rm)
+        //   ldb = D = 252 (cm rows of X_rm)
+        //   ldc = K = 462 (cm rows of Y_rm-as-Y^T_cm)
+        let gemm_cfg = GemmConfig::<f32> {
+            transa: cublasOperation_t::CUBLAS_OP_T,
+            transb: cublasOperation_t::CUBLAS_OP_N,
+            m: NUM_KEEPERS_F as i32,
+            n: batch_i32,
+            k: NUM_DICE_F as i32,
+            alpha: 1.0,
+            lda: NUM_DICE_F as i32,
+            ldb: NUM_DICE_F as i32,
+            beta: 0.0,
+            ldc: NUM_KEEPERS_F as i32,
+        };
+        unsafe {
+            self.blas.gemm(
+                gemm_cfg,
+                &self.keepers_to_dice,
+                &third_dice,
+                &mut second_keepers,
+            )?;
+        }
+
+        // ------- Step 3: masked_max → second_dice -------------------------
+        // Grid: (batch, 252, 1) blocks of (REDUCE_BLOCK_DIM, 1, 1) threads.
+        // batch on x (no cap), dice_idx on y (252 < 65535).
+        let cfg_reduce = LaunchConfig {
+            grid_dim: (batch as u32, NUM_DICE_F as u32, 1),
+            block_dim: (REDUCE_BLOCK_DIM, 1, 1),
+            shared_mem_bytes: REDUCE_BLOCK_DIM * std::mem::size_of::<f32>() as u32,
+        };
+        unsafe {
+            stream
+                .launch_builder(&self.f_masked_max)
+                .arg(&second_keepers)
+                .arg(&self.dice_to_keepers)
+                .arg(&mut second_dice)
+                .arg(&batch_i32)
+                .launch(cfg_reduce)?;
+        }
+
+        // ------- Step 4: keepers_from_dice via cuBLAS sgemm (again) -------
+        unsafe {
+            self.blas.gemm(
+                gemm_cfg,
+                &self.keepers_to_dice,
+                &second_dice,
+                &mut first_keepers,
+            )?;
+        }
+
+        // ------- Step 5: masked_max → first_dice --------------------------
+        unsafe {
+            stream
+                .launch_builder(&self.f_masked_max)
+                .arg(&first_keepers)
+                .arg(&self.dice_to_keepers)
+                .arg(&mut first_dice)
+                .arg(&batch_i32)
+                .launch(cfg_reduce)?;
+        }
+
+        // ------- Step 6: initial_roll_ev → result -------------------------
+        // row0 of KEEPERS_TO_DICE_PROBABILITIES occupies offsets [0..252] of
+        // the row-major (462, 252) buffer, so we just pass `keepers_to_dice`
+        // and the kernel reads `row0[d]` from the first 252 elements.
+        let cfg_marg = LaunchConfig {
+            grid_dim: (batch as u32, 1, 1),
+            block_dim: (REDUCE_BLOCK_DIM, 1, 1),
+            shared_mem_bytes: REDUCE_BLOCK_DIM * std::mem::size_of::<f32>() as u32,
+        };
+        unsafe {
+            stream
+                .launch_builder(&self.f_initial_roll_ev)
+                .arg(&first_dice)
+                .arg(&self.keepers_to_dice)
+                .arg(&mut result)
+                .arg(&batch_i32)
+                .launch(cfg_marg)?;
+        }
+
+        // ------- D→H result -----------------------------------------------
+        let host_result = stream.clone_dtoh(&result)?;
+        stream.synchronize()?;
+        Ok(host_result)
+    }
+}
+
+impl BuildBackend for CudaBuildBackend {
+    fn compute_level(&self, states: &[State], state_scores: &[f32]) -> Vec<f32> {
+        if states.is_empty() {
+            return Vec::new();
+        }
+        // BuildBackend is infallible from the caller's perspective; CUDA
+        // failure mid-build is fatal (the DP table would be wrong) so we
+        // panic with the underlying error rather than silently returning
+        // bad data. There's no recovery path: the host-side `Scores::new_with`
+        // doesn't have a way to retry on a different backend.
+        self.compute_level_inner(states, state_scores)
+            .expect("CUDA compute_level failed")
+    }
+}


### PR DESCRIPTION
## Summary
  Refactors the DP inner loop behind two swappable abstractions so alternative implementations (BLAS, faer, hand-vectorized SIMD, CUDA) can be benched head-to-head without forking `Scores`. This PR is groundwork — no perf change
   vs. the pre-refactor `ndarray` baseline; later PRs land the actual wins on top.                                                                                                                                                  
   
  - **`LinalgBackend` (per-state)**: 3 primitives — `keepers_from_dice`, `dice_from_keepers`, `initial_roll_ev`. Implementations: `NdarrayBackend` (default, `matrixmultiply`; `cblas_sgemv` under `--features blas`), `FaerBackend`
   (opt-in `--features faer`), `SimdBackend` (opt-in `--features simd`, hand-vectorized masked-max via `wide::f32x8`), `NaiveBackend` (always-on scalar reference / oracle).
  (generic over `LinalgBackend`), `CudaBuildBackend` (opt-in `--features cuda`, full NVRTC + cuBLAS pipeline via `cudarc`, device-resident state_scores).                                                                           
  - **CUDA specifics**: dynamic-loaded (`libcuda` / `libcublas` / `libnvrtc` `.so`s at runtime — no `nvcc` at build time). `compute_level` is fallible (`Error = CudaError`); device buffers persist across levels.                 
  - **Bench**: `criterion` group `Scores::new_with/backends` runs the full-build across all enabled backends.                                                                                                      
  - **Ad-hoc infra**: `--features blas` on `yahtzee-core`.                                                                                                                                                                          
                                                          
  ## Test plan                                                                                                                                                                                                                      
  - [x] `cargo test -p yahtzee-core --release` — proptests + `test_naive_backend_matches` pass
  - [x `cargo test -p yahtzee-core --release --features simd,faer` — same, all backends agree                                                                                                                                      
  - [x] `cargo bench -p yahtzee-core --bench recommend -- "Scores::new_with/backends"` — completes without regression vs. the ndarray-only baseline                                                                                 
  - [x] `cargo build -p yahtzee-core --release --features cuda` builds on a host with `libcuda`+`libcublas`+`libnvrtc` available; smoke test via `cargo run -p yahtzee-core --release --example cuda_smoke --features cuda`