### PR TITLE
CLI: default to SIMD backend + add unvalidated-DP path & cross-backend ranking proptest.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ A `State` is `(entries: EntryAction bitflags, yahtzee_bonus_eligible: bool, uppe
 
 `Scores::new_with<B: BuildBackend>(backend: &B) -> Result<Self, B::Error>` is the generic constructor; `Scores::new()` calls it with `&CpuBuildBackend` and unwraps the `Infallible` result. Use `new_with` directly to opt into a non-default backend (e.g. `&CudaBuildBackend::new()?` under the `cuda` feature).
 
+`Scores::new_with_unvalidated<B>` is the sibling that skips the BFS-reachability filter in the per-level batch enumeration: every structurally possible state at each level enters the DP, including the ~512k that no real game reaches. ~2× build wall-clock vs `new_with`. Used (a) as a soundness oracle for the BFS — `test_unvalidated_matches_validated` (gated `#[ignore]`) cross-checks that the validated and unvalidated tables agree on every reachable state's EV, and (b) as the substrate for any future fast path that wants regular per-level batch shapes (outer-loop SIMD across states, level-specialized GPU kernels). Today the validated path is what `Scores::new` uses; the unvalidated one is opt-in.
+
 `Scores::values(state)` returns an `ExpectedValues` by walking the three-roll decision tree in reverse, dispatching the linalg ops through a [`LinalgBackend`](#linalg-and-build-backends):
 
 1. `entry_actions[action, dice]` = immediate score of taking `action` on `dice` + stored EV of the resulting child state (via `State::score_and_child`, which handles upper bonus, Yahtzee bonus, and the joker rule).
@@ -97,7 +99,7 @@ For external comparison: the `timpalpant/yahtzee` Go reference takes ~45 s for t
 Helpful entry points:
 - **Examples**: `crates/core/examples/time_build.rs` (default), `time_build_naive.rs`, `cuda_smoke.rs`.
 - **Benches**: `crates/core/benches/recommend.rs` — see the `bench_backends` (per-state) and `bench_build_backends` (full builds) groups.
-- **Cross-check test**: `test_naive_backend_matches` asserts naive and ndarray agree on default-state EV within 1e-3.
+- **Cross-check tests**: `test_naive_backend_matches` asserts naive and ndarray agree on the default-state EV within 1e-3 (single scalar tripwire). `proptests::linalg_backends_agree_on_action_ranking` is the broader cousin: for `arb_state() × dice_idx`, every enabled `LinalgBackend` (naive, ndarray, optionally faer/simd) must produce the same overall EV *and* the same EV at each rank in the sorted entries / first_keepers / second_keepers lists, within 5e-3. This catches structural backend bugs that nudge EVs by ~1e-2 on niche states — well below the default-state test's noise floor. `test_unvalidated_matches_validated` (gated `#[ignore]`, run with `cargo test -p yahtzee-core --release -- --ignored`) compares `Scores::new_with` against `Scores::new_with_unvalidated` across every reachable state — i.e. cross-checks the BFS soundness as a side effect.
 
 ### Scoring helpers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,15 @@ Private helpers `turn_ev_by_roll3_dice()` and `turn_ev_by_roll2_dice(...)` build
 
 `Scores` derives `Serialize` / `Deserialize` and is persisted with `bincode`. The CLI (`crates/cli/src/main.rs`) is `clap`-subcommand-based — see the Commands section above for the four subcommands (`solve`, `value`, `play`, `build`) and how `--scores PATH` overrides the embedded score table. The `--entries` argument used by `solve` / `value` is a 13-character `0`/`1` string aligned with `ENTRY_ACTIONS` order.
 
-Both the CLI and wasm crates currently consume `yahtzee-core` with default features only (so the table-build path uses `CpuBuildBackend` → `NdarrayBackend`). The faster CPU backends (`simd`, `faer`) are gated behind features that neither downstream crate enables today; switching the CLI's `build` subcommand to use `simd` is a 1.84× wall-clock win with no API change. `cuda` is more situational (driver libs at runtime, NVIDIA-only) but plausible as an opt-in `cuda` feature on the CLI.
+CLI feature wiring (`crates/cli/Cargo.toml`):
+
+- `default = ["simd"]` — the `build` subcommand dispatches through `CpuBuildBackendWith(SimdBackend)` (~1.84× wall-clock vs `NdarrayBackend`, no API change). The `solve` / `value` / `play` subcommands deserialize the embedded table and don't hit `Scores::new()` regardless of features, so this only affects table regeneration.
+- `cuda` (opt-in) — when compiled (`cargo build -p yahtzee-cli --release --features cuda`), `build` dispatches through `CudaBuildBackend` instead, taking precedence over `simd`. Requires `libcuda` / `libcublas` / `libnvrtc` `.so`s on the runtime host (cudarc dynamic-loads, no CUDA SDK at build time). If GPU init fails the subcommand errors out — there's no automatic CPU fallback.
+- `--no-default-features` — falls back to `Scores::new()` (`NdarrayBackend`). Useful for benching the unaccelerated path.
+
+The selection is compile-time (`cfg`-gated `build_scores()` in `crates/cli/src/main.rs`), not a runtime flag.
+
+The wasm crate intentionally consumes `yahtzee-core` with default features only. It deserializes the embedded brotli blob rather than calling `Scores::new()`, so `simd` / `faer` / `cuda` would only affect the per-state `Scores::values()` walk (~100 µs/call, single-call-per-UI-action) — not worth a feature surface or extra deps. The canonical `scores.bin.br` is regenerated through the CLI's `build` subcommand, so backend-driven build wins land via the CLI path.
 
 `crates/wasm/src/lib.rs` exposes:
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,24 @@ edition = "2024"
 name = "easy-yahtzee"
 path = "src/main.rs"
 
+[features]
+# Drive `easy-yahtzee build` through `CpuBuildBackendWith(SimdBackend)` instead
+# of the default `NdarrayBackend`. ~1.84× wall-clock win on a 16-thread Ryzen
+# (5.73s → 3.11s); no runtime deps beyond what `yahtzee-core[simd]` already
+# pulls in. Pure default-on win — disable only with `--no-default-features` if
+# you specifically want to bench the unaccelerated path.
+default = ["simd"]
+simd = ["yahtzee-core/simd"]
+
+# Opt-in: drive `easy-yahtzee build` through `CudaBuildBackend` (per-level
+# batched on an NVIDIA GPU via cudarc). ~9× over naive, ~3.3× over `simd`.
+# Situational because it needs `libcuda` / `libcublas` / `libnvrtc` `.so`s on
+# the runtime host (NVIDIA-only). When `cuda` is enabled it takes precedence
+# over `simd` in the `build` subcommand. If GPU init fails (e.g. no driver),
+# the build subcommand returns an error rather than silently falling back —
+# rebuild without `--features cuda` to use the CPU path.
+cuda = ["yahtzee-core/cuda"]
+
 [dependencies]
 yahtzee-core = { path = "../core" }
 anyhow = "1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -216,8 +216,7 @@ fn cmd_build(args: BuildArgs) -> Result<()> {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
 
-    eprintln!("[build] computing Scores::new() ...");
-    let scores = Scores::new();
+    let scores = build_scores()?;
 
     eprintln!("[build] serializing with bincode ...");
     let raw: Vec<u8> = bincode::serde::encode_to_vec(&scores, bincode::config::standard())
@@ -283,6 +282,35 @@ fn cmd_build(args: BuildArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 // Helpers: scores I/O, state construction
 // ---------------------------------------------------------------------------
+
+/// Build a fresh `Scores` table for the `build` subcommand, using the fastest
+/// `BuildBackend` that was compiled in. Selection is feature-gated, *not* a
+/// runtime flag: `--features cuda` ⇒ GPU; otherwise default `simd` ⇒
+/// `CpuBuildBackendWith(SimdBackend)`; otherwise plain `Scores::new()`
+/// (`NdarrayBackend`). See `[features]` in `Cargo.toml` for the trade-offs.
+fn build_scores() -> Result<Scores> {
+    #[cfg(feature = "cuda")]
+    {
+        use yahtzee_core::linalg::CudaBuildBackend;
+        eprintln!("[build] computing Scores::new() via CudaBuildBackend ...");
+        let backend = CudaBuildBackend::new()
+            .context("initializing CUDA backend (libcuda/libcublas/libnvrtc on runtime host?)")?;
+        return Scores::new_with(&backend).context("CUDA Scores::new_with");
+    }
+    #[cfg(all(feature = "simd", not(feature = "cuda")))]
+    {
+        use yahtzee_core::linalg::{CpuBuildBackendWith, SimdBackend};
+        eprintln!("[build] computing Scores::new() via CpuBuildBackendWith(SimdBackend) ...");
+        let backend = CpuBuildBackendWith(SimdBackend::new());
+        // CpuBuildBackendWith::Error is Infallible — unwrap is statically safe.
+        return Ok(Scores::new_with(&backend).unwrap());
+    }
+    #[cfg(not(any(feature = "simd", feature = "cuda")))]
+    {
+        eprintln!("[build] computing Scores::new() via NdarrayBackend ...");
+        Ok(Scores::new())
+    }
+}
 
 /// The canonical solver table, brotli-compressed bincode of `Scores`. Tracked
 /// in git at `crates/cli/data/scores.bin.br` so fresh clones can build the CLI

--- a/crates/core/examples/time_build.rs
+++ b/crates/core/examples/time_build.rs
@@ -7,20 +7,66 @@
 //!     RAYON_NUM_THREADS=1  cargo run -p yahtzee-core --release --example time_build
 //!     RAYON_NUM_THREADS=8  cargo run -p yahtzee-core --release --example time_build
 //!
-//! Output is one line: `threads=<n> elapsed_ms=<ms> default_ev=<ev>`.
+//! Set `YAHTZEE_UNVALIDATED=1` to drive `Scores::new_with_unvalidated` instead
+//! (skips the BFS-reachability filter; ~2× build wall-clock; correctness-
+//! identical for reachable states).
+//!
+//! Set `YAHTZEE_BACKEND=ndarray|naive|simd|faer` to swap the per-state
+//! `LinalgBackend` driving the build (`ndarray` is the default; `simd` and
+//! `faer` require their respective Cargo features). The 2×2 matrix:
+//!
+//!     cargo run -p yahtzee-core --release --features simd --example time_build
+//!     YAHTZEE_UNVALIDATED=1 cargo run -p yahtzee-core --release --features simd --example time_build
+//!     YAHTZEE_BACKEND=simd cargo run -p yahtzee-core --release --features simd --example time_build
+//!     YAHTZEE_UNVALIDATED=1 YAHTZEE_BACKEND=simd cargo run -p yahtzee-core --release --features simd --example time_build
+//!
+//! Output is one line: `threads=<n> backend=<b> mode=<m> elapsed_ms=<ms> default_ev=<ev>`.
 
 use std::time::Instant;
 
-use yahtzee_core::{Scores, State};
+use yahtzee_core::{
+    BuildBackend, CpuBuildBackend, CpuBuildBackendWith, NaiveBackend, Scores, State,
+};
 
 fn main() {
     let threads = std::env::var("RAYON_NUM_THREADS").unwrap_or_else(|_| "default".to_string());
+    let unvalidated = std::env::var("YAHTZEE_UNVALIDATED").ok().is_some();
+    let backend_name = std::env::var("YAHTZEE_BACKEND").unwrap_or_else(|_| "ndarray".to_string());
+
     let t0 = Instant::now();
-    let scores = Scores::new();
+    let scores = match backend_name.as_str() {
+        "ndarray" => run(&CpuBuildBackend, unvalidated),
+        "naive" => run(&CpuBuildBackendWith(NaiveBackend), unvalidated),
+        #[cfg(feature = "simd")]
+        "simd" => run(
+            &CpuBuildBackendWith(yahtzee_core::linalg::SimdBackend::new()),
+            unvalidated,
+        ),
+        #[cfg(feature = "faer")]
+        "faer" => run(
+            &CpuBuildBackendWith(yahtzee_core::linalg::FaerBackend::new()),
+            unvalidated,
+        ),
+        other => panic!("unknown YAHTZEE_BACKEND={other:?} (or feature not enabled)"),
+    };
     let elapsed = t0.elapsed();
+
     let ev = scores.state_value(State::default());
+    let mode = if unvalidated { "unvalidated" } else { "validated" };
     println!(
-        "threads={threads} elapsed_ms={:.1} default_ev={ev:.4}",
+        "threads={threads} backend={backend_name} mode={mode} elapsed_ms={:.1} default_ev={ev:.4}",
         elapsed.as_secs_f64() * 1000.0
     );
+}
+
+fn run<B>(backend: &B, unvalidated: bool) -> Scores
+where
+    B: BuildBackend,
+    B::Error: std::fmt::Debug,
+{
+    if unvalidated {
+        Scores::new_with_unvalidated(backend).expect("build failed")
+    } else {
+        Scores::new_with(backend).expect("build failed")
+    }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -385,6 +385,20 @@ const VALID_STATES_WORDS: usize = (NUM_STATES as usize).div_ceil(64);
 // `Scores::values` call the default `NdarrayBackend` and behave identically;
 // the `_with` variants accept any backend for benchmarking.
 
+/// Whether the DP build filters per-level batches against the BFS-reachability
+/// bitmap. Internal selector for [`Scores::new_with`] vs
+/// [`Scores::new_with_unvalidated`]; not user-facing.
+#[derive(Copy, Clone)]
+enum BuildMode {
+    /// Filter the level batch through `valid_state()` — only BFS-reachable
+    /// states get DP'd. ~50% smaller batches, ~2× faster end-to-end.
+    Validated,
+    /// Process every state at the level, reachable or not. ~2× more compute
+    /// but trivially correct: any latent BFS-soundness bug becomes a no-op
+    /// (every state's child is also in the batch by construction).
+    Unvalidated,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scores {
     state_scores: Array1<f32>,
@@ -481,19 +495,55 @@ impl Scores {
     /// backends can fail (driver errors, out-of-memory, kernel launch
     /// failure) — call this directly with `&CudaBuildBackend` and handle
     /// the error.
+    ///
+    /// This is the validated path: per-level batches are filtered by the
+    /// BFS-reachability bitmap, so we only run the DP over the ~536k of 1M
+    /// states that any real game can visit. See
+    /// [`Scores::new_with_unvalidated`] for the trivially-correct sibling
+    /// that skips the filter (and processes all ~1M states per build).
     pub fn new_with<B: BuildBackend>(backend: &B) -> Result<Scores, B::Error> {
+        Self::build(backend, BuildMode::Validated)
+    }
+
+    /// Like [`Scores::new_with`], but with the per-level filter against the
+    /// reachability bitmap disabled — every structurally-possible state at
+    /// each level enters the DP batch, including the ~512k that no actual
+    /// game can ever reach. The resulting [`Scores`] table is correct for
+    /// every reachable state by construction (DP recurrence is closed
+    /// under reachability), and additionally carries well-defined EVs for
+    /// the unreachable ones (which nothing reads).
+    ///
+    /// Roughly 2× the build wall-clock vs `new_with`. The point isn't
+    /// speed, it's *regularity*: the per-level batch shape becomes a
+    /// known-at-compile-time function of the level alone, which is what
+    /// outer-loop SIMD and level-specialized GPU kernels want. Use this
+    /// for cross-checking the BFS soundness and as the substrate for any
+    /// future unvalidated fast path.
+    pub fn new_with_unvalidated<B: BuildBackend>(backend: &B) -> Result<Scores, B::Error> {
+        Self::build(backend, BuildMode::Unvalidated)
+    }
+
+    fn build<B: BuildBackend>(backend: &B, mode: BuildMode) -> Result<Scores, B::Error> {
         let state_scores = Array1::zeros(NUM_STATES as usize);
         let valid_states = vec![0_u64; VALID_STATES_WORDS].into_boxed_slice();
         let mut scores = Scores {
             state_scores,
             valid_states,
         };
+        // Always populate the BFS bitmap so `Scores::valid_state()` retains
+        // its meaning ("reachable from default state") regardless of build
+        // mode. The mode only controls whether the per-level enumeration
+        // *uses* the bitmap as a filter.
         scores.set_valid_states();
-        scores.set_scores(backend)?;
+        scores.set_scores(backend, mode)?;
         Ok(scores)
     }
 
-    fn set_scores<B: BuildBackend>(&mut self, backend: &B) -> Result<(), B::Error> {
+    fn set_scores<B: BuildBackend>(
+        &mut self,
+        backend: &B,
+        mode: BuildMode,
+    ) -> Result<(), B::Error> {
         // Bottom-up by level (most filled entries first) so each level only
         // reads strictly-higher-level state scores. Within a level, all
         // states are independent — that's the parallelism the BuildBackend
@@ -501,7 +551,7 @@ impl Scores {
         let trace = std::env::var("YAHTZEE_TRACE_LEVELS").ok().is_some();
         for level in (0..NUM_ENTRY_ACTIONS).rev() {
             let t_collect = std::time::Instant::now();
-            let states = self.collect_states_at_level(level as usize);
+            let states = self.collect_states_at_level(level as usize, mode);
             let collect_ms = t_collect.elapsed().as_secs_f64() * 1000.0;
             if states.is_empty() {
                 continue;
@@ -529,21 +579,27 @@ impl Scores {
         Ok(())
     }
 
-    /// All valid states at exactly the given DP level (`level` = number of
-    /// entries filled). Returned in `usize`-encoded ascending order; the
-    /// `BuildBackend` doesn't depend on the order, but a stable order makes
-    /// debugging easier.
-    fn collect_states_at_level(&self, level: usize) -> Vec<State> {
+    /// States at exactly the given DP level. In [`BuildMode::Validated`]
+    /// (the default), only BFS-reachable states are returned (~half the
+    /// state space). In [`BuildMode::Unvalidated`], every structurally
+    /// possible state at the level is returned.
+    ///
+    /// Returned in `usize`-encoded ascending order; the `BuildBackend`
+    /// doesn't depend on the order, but a stable order makes debugging
+    /// easier.
+    fn collect_states_at_level(&self, level: usize, mode: BuildMode) -> Vec<State> {
         // Parallel filter is cheap (tens of ms across all 13 levels) and not
         // worth optimizing further; the inner DP per state dominates.
         (0..NUM_STATES as usize)
             .into_par_iter()
             .filter_map(|idx| {
                 let state: State = idx.into();
-                if self.valid_state(state) && state.level() == level {
-                    Some(state)
-                } else {
-                    None
+                if state.level() != level {
+                    return None;
+                }
+                match mode {
+                    BuildMode::Validated if !self.valid_state(state) => None,
+                    _ => Some(state),
                 }
             })
             .collect()
@@ -1079,6 +1135,65 @@ mod tests {
         let scores = shared_scores();
         let expected_value = scores.state_scores[default_idx];
         assert!((expected_value - 254.5896).abs() < 0.0001);
+    }
+
+    /// Cross-check: `Scores::new_with_unvalidated` should produce EVs
+    /// identical (within float reduction-order tolerance) to
+    /// `Scores::new_with` for every BFS-reachable state.
+    ///
+    /// What this catches: if the BFS in `set_valid_states` has any false
+    /// negatives — i.e. it marks some actually-reachable state as
+    /// unreachable — the validated path leaves that state's EV at 0.0,
+    /// which propagates into its parents' EVs as a wrong (low) value.
+    /// The unvalidated path has no such gap (every level processes every
+    /// state), so a divergence here is exactly a BFS-soundness bug.
+    ///
+    /// Gated `#[ignore]` because it builds a second `Scores` table
+    /// (~doubles the test wall-clock). Run explicitly with
+    /// `cargo test -p yahtzee-core --release -- --ignored
+    /// test_unvalidated_matches_validated`.
+    #[test]
+    #[ignore]
+    fn test_unvalidated_matches_validated() {
+        let validated = shared_scores();
+        let unvalidated = Scores::new_with_unvalidated(&CpuBuildBackend).unwrap();
+
+        let v = validated.state_scores_slice();
+        let u = unvalidated.state_scores_slice();
+        assert_eq!(v.len(), u.len());
+
+        let mut mismatches = 0_usize;
+        let mut max_abs_diff = 0.0_f32;
+        let mut unreachable_nonzero = 0_usize;
+
+        for idx in 0..(NUM_STATES as usize) {
+            let state: State = idx.into();
+            let diff = (v[idx] - u[idx]).abs();
+            if validated.valid_state(state) {
+                if diff > 1e-3 {
+                    mismatches += 1;
+                    if diff > max_abs_diff {
+                        max_abs_diff = diff;
+                    }
+                }
+            } else if u[idx] != 0.0 {
+                // Informational: unreachable states may have nonzero EVs in
+                // the unvalidated table because the DP visits them. As long
+                // as the validated path agrees on every *reachable* state,
+                // these don't affect anything observable.
+                unreachable_nonzero += 1;
+            }
+        }
+
+        eprintln!(
+            "unvalidated cross-check: {unreachable_nonzero} unreachable states \
+             with nonzero EV in the unvalidated table (informational; expected)"
+        );
+        assert_eq!(
+            mismatches, 0,
+            "validated and unvalidated tables disagree on {mismatches} reachable states; \
+             max |Δ| = {max_abs_diff}",
+        );
     }
 
     /// NaiveBackend (scalar `for` loops, no ndarray ops) should produce the

--- a/crates/core/src/proptests.rs
+++ b/crates/core/src/proptests.rs
@@ -194,4 +194,85 @@ proptest! {
             "state={state:?} dice_idx={dice_idx} opt={opt} ref={reference}",
         );
     }
+
+    /// Cross-check the action-ranking outputs across all enabled
+    /// [`LinalgBackend`]s. For any `(state, dice)`, every backend should
+    /// produce the same overall EV and the same EV at each rank in the
+    /// sorted entries / first_keepers / second_keepers lists (within float
+    /// reduction-order tolerance). Choices may swap *within* an EV-tie
+    /// bucket — that's fine; we compare EVs at each position, not choices.
+    ///
+    /// What this catches that `test_*_backend_matches` doesn't: those tests
+    /// only check the default-state scalar EV. This walks the full
+    /// recommendation surface (252 dice × ~8000 sampled states × {1,2,3}
+    /// rolls' worth of ranked choices), so a backend bug that nudges
+    /// EV-by-1e-2 on a niche state — well within the noise of the
+    /// default-state test — shows up here.
+    #[test]
+    fn linalg_backends_agree_on_action_ranking(
+        state in arb_state(),
+        dice_idx in 0u8..NUM_DICE_COMBINATIONS,
+    ) {
+        let scores = shared_scores();
+        let dice = dice_list()[dice_idx as usize].clone();
+
+        // Naive is the always-on, no-deps oracle. Other backends are
+        // feature-gated; collect a Vec<(name, ExpectedValues)> of whichever
+        // ones are compiled in and cross-check each against naive.
+        let oracle = scores.values_with(state, &NaiveBackend);
+        #[allow(unused_mut)]
+        let mut others: Vec<(&'static str, ExpectedValues)> =
+            vec![("ndarray", scores.values_with(state, &NdarrayBackend))];
+        #[cfg(feature = "faer")]
+        others.push(("faer", scores.values_with(state, &linalg::FaerBackend::new())));
+        #[cfg(feature = "simd")]
+        others.push(("simd", scores.values_with(state, &linalg::SimdBackend::new())));
+
+        for (name, candidate) in &others {
+            prop_assert!(
+                (oracle.value - candidate.value).abs() <= TOL,
+                "value: naive={} {name}={} state={state:?}",
+                oracle.value, candidate.value,
+            );
+
+            // Roll 3: ranked entries (immediate score for each action).
+            let oe = oracle.entries_score(dice.clone());
+            let ce = candidate.entries_score(dice.clone());
+            prop_assert_eq!(
+                oe.len(), ce.len(),
+                "entries len differs for {}", name,
+            );
+            for (i, (a, b)) in oe.iter().zip(ce.iter()).enumerate() {
+                prop_assert!(
+                    (a.1 - b.1).abs() <= TOL,
+                    "entries rank {i}: naive={} {name}={} \
+                     state={state:?} dice_idx={dice_idx}",
+                    a.1, b.1,
+                );
+            }
+
+            // Rolls 1 & 2: ranked keepers.
+            for (label, oa, ca) in [
+                ("first_keepers",
+                    oracle.first_keepers_score(dice.clone()),
+                    candidate.first_keepers_score(dice.clone())),
+                ("second_keepers",
+                    oracle.second_keepers_score(dice.clone()),
+                    candidate.second_keepers_score(dice.clone())),
+            ] {
+                prop_assert_eq!(
+                    oa.len(), ca.len(),
+                    "{} len differs for {}", label, name,
+                );
+                for (i, (a, b)) in oa.iter().zip(ca.iter()).enumerate() {
+                    prop_assert!(
+                        (a.1 - b.1).abs() <= TOL,
+                        "{label} rank {i}: naive={} {name}={} \
+                         state={state:?} dice_idx={dice_idx}",
+                        a.1, b.1,
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
  Two independent-but-adjacent changes bundled to keep PR count down. Neither touches on-disk
  artifacts (`scores.bin.br` embed unaffected).

  ### 1. CLI defaults to `SimdBackend` (`fb3bac0`)
  - `easy-yahtzee build` now dispatches through `CpuBuildBackendWith(SimdBackend)` by default —
   ~1.84× wall-clock on the table regeneration path, no API change.
  - `--features cuda` further overrides to `CudaBuildBackend` (takes precedence over `simd`).
  - `--no-default-features` falls back to the unaccelerated `NdarrayBackend`.
  - Compile-time selection via a `cfg`-gated `build_scores()` helper — not a runtime flag.
  - `solve` / `value` / `play` are untouched (they read the embedded `scores.bin.br` and never
  call `Scores::new()`).
  - Wasm intentionally stays on default features — no build path at runtime, and per-state
  `values()` is sub-ms either way.

  ### 2. Unvalidated DP path + broader proptest (`2bff6f1`)
  - **`Scores::new_with_unvalidated<B>`**: skips the BFS-reachability filter on per-level
  batches. Every structurally possible state enters the DP. ~1.93× build wall-clock vs.
  `new_with`, identical EVs on every reachable state.
  - **Why keep it around**:
    1. *Soundness oracle for the BFS.* `test_unvalidated_matches_validated` (gated `#[ignore]`)
   cross-checks against `new_with` on all 536,448 reachable states — today: 0 mismatches. A BFS
   false-negative would show up here as an EV divergence.
    2. *Substrate for regular-batch (C(13, L) × 128) architectures.* Closed-form batch shape,
  no scan/filter, potentially better for outer-loop SIMD in a future round. Today's validated
  stays default.
  - **`proptests::linalg_backends_agree_on_action_ranking`**: for `arb_state() × dice_idx`,
  every enabled `LinalgBackend` must produce the same overall EV *and* the same EV at each rank
  - Wasm intentionally stays on default features — no build path at runtime, and per-state `values()` is sub-ms either way.

  ### 2. Unvalidated DP path + broader proptest (`2bff6f1`)
  - **`Scores::new_with_unvalidated<B>`**: skips the BFS-reachability filter on per-level batches. Every structurally possible state enters the DP. ~1.93× build wall-clock vs. `new_with`, identical EVs on every reachable state.
  - **Why keep it around**:
    1. *Soundness oracle for the BFS.* `test_unvalidated_matches_validated` (gated `#[ignore]`) cross-checks against `new_with` on all 536,448 reachable states — today: 0 mismatches. A BFS false-negative would show up here as an EV divergence.
    2. *Substrate for regular-batch (C(13, L) × 128) architectures.* Closed-form batch shape, no scan/filter, potentially better for outer-loop SIMD in a future round. Today's validated stays default.
  - **`proptests::linalg_backends_agree_on_action_ranking`**: for `arb_state() × dice_idx`, every enabled `LinalgBackend` must produce the same overall EV *and* the same EV at each rank in the sorted entries / first_keepers / second_keepers lists (within 5e-3). Catches structural
  backend bugs the default-state scalar tripwire would miss.
  - **`time_build` example**: extended with `YAHTZEE_BACKEND={ndarray,naive,simd,faer}` and `YAHTZEE_UNVALIDATED=1` env vars so the 2×4 matrix is one-liner-able.

  ## Test plan
  - [x] `cargo test -p yahtzee-core --release --features simd,faer` — proptests + oracle tests pass
  - [x] `cargo test -p yahtzee-core --release --features simd -- --ignored` — `test_unvalidated_matches_validated` reports 0 mismatches
  - [x] `cargo run -p yahtzee-cli --release -- build --output /tmp/scores.bin --brotli` — completes without regression, output byte-identical to previous canonical
  - [x] `cargo run -p yahtzee-cli --release --no-default-features -- build --output /tmp/scores_ndarray.bin --brotli` — same output, slower wall-clock
  - [x] `YAHTZEE_BACKEND=naive YAHTZEE_UNVALIDATED=1 cargo run -p yahtzee-core --release --example time_build` — prints valid timing + EV 254.5897